### PR TITLE
add no-op processor + example sources

### DIFF
--- a/immutable-processor/build.gradle
+++ b/immutable-processor/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+    id 'org.example.immutable.java-conventions'
+    id 'java-library'
+}
+
+dependencies {
+    compileOnly 'com.google.auto.service:auto-service-annotations:1.0.1'
+    annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
+
+    implementation project(':immutable-annotations')
+
+    testImplementation 'com.google.testing.compile:compile-testing:0.19'
+}
+
+test {
+    // See: https://github.com/google/compile-testing/issues/222
+    jvmArgs '--add-opens=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableProcessor.java
@@ -1,0 +1,51 @@
+package org.example.immutable.processor;
+
+import com.google.auto.service.AutoService;
+import java.util.Set;
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.Immutable;
+
+/** Processes interfaces annotated with {@link Immutable}. */
+@AutoService(Processor.class)
+public final class ImmutableProcessor implements Processor {
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(Immutable.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public void init(ProcessingEnvironment processingEnv) {
+        // TODO: Implement me.
+    }
+
+    @Override
+    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        // TODO: Implement me.
+        return false;
+    }
+
+    @Override
+    public Iterable<? extends Completion> getCompletions(
+            Element element, AnnotationMirror annotationMirror, ExecutableElement executableElement, String s) {
+        return Set.of();
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
@@ -1,0 +1,26 @@
+package org.example.immutable.processor;
+
+import org.example.immutable.processor.test.TestCompiler;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableProcessorTest {
+
+    @Test
+    public void compileWithoutVerifyingSource_Rectangle() {
+        compileWithoutVerifyingSource("test/Rectangle.java");
+    }
+
+    @Test
+    public void compileWithoutVerifyingSource_ColoredRectangle() {
+        compileWithoutVerifyingSource("test/ColoredRectangle.java");
+    }
+
+    @Test
+    public void compileWithoutVerifyingSource_Empty() {
+        compileWithoutVerifyingSource("test/Empty.java");
+    }
+
+    private void compileWithoutVerifyingSource(String sourcePath) {
+        TestCompiler.create().compile(sourcePath);
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
@@ -1,0 +1,63 @@
+package org.example.immutable.processor.test;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import javax.annotation.processing.Processor;
+import javax.tools.JavaFileObject;
+import org.example.immutable.processor.ImmutableProcessor;
+
+/**
+ * Compiles sources with {@link ImmutableProcessor}.
+ *
+ * <p>It checks that the sources compile both without and with the annotation processor.</p>
+ */
+public class TestCompiler {
+
+    private Processor processor;
+
+    /** Creates a compiler with {@link ImmutableProcessor}. */
+    public static TestCompiler create() {
+        Processor processor = new ImmutableProcessor();
+        return new TestCompiler(processor);
+    }
+
+    private TestCompiler(Processor processor) {
+        this.processor = processor;
+    }
+
+    /** Compiles the sources, verifying the status of the compilation. */
+    public Compilation compile(String... sourcePaths) {
+        return compile(List.of(sourcePaths));
+    }
+
+    /** Compiles the sources, verifying the status of the compilation. */
+    public Compilation compile(Iterable<String> sourcePaths) {
+        List<JavaFileObject> sourceFiles = StreamSupport.stream(sourcePaths.spliterator(), false)
+                .map(JavaFileObjects::forResource)
+                .toList();
+        compileWithoutProcessor(sourceFiles);
+        return compileWithProcessor(sourceFiles);
+    }
+
+    /** Compiles the sources with the annotation processor, verifying the status of the compilation. */
+    private Compilation compileWithProcessor(Iterable<JavaFileObject> sourceFiles) {
+        Compilation compilation = Compiler.javac()
+                .withProcessors(processor)
+                // Suppress this warning: "Implicitly compiled files were not subject to annotation processing."
+                .withOptions("-implicit:none")
+                .compile(sourceFiles);
+        assertThat(compilation).succeededWithoutWarnings();
+        return compilation;
+    }
+
+    /** Compiles the sources without the annotation processor, verifying the status of the compilation. */
+    private void compileWithoutProcessor(Iterable<JavaFileObject> sourceFiles) {
+        Compilation compilation = Compiler.javac().compile(sourceFiles);
+        assertThat(compilation).succeededWithoutWarnings();
+    }
+}

--- a/immutable-processor/src/test/resources/generated/test/ImmutableColoredRectangle.java
+++ b/immutable-processor/src/test/resources/generated/test/ImmutableColoredRectangle.java
@@ -1,0 +1,34 @@
+package test;
+
+import java.awt.Color;
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated("org.example.immutable.processor.ImmutableProcessor")
+class ImmutableColoredRectangle implements ColoredRectangle {
+
+    private final Rectangle rectangle;
+    private final Color fillColor;
+    private final Optional<Color> edgeColor;
+
+    ImmutableColoredRectangle(Rectangle rectangle, Color fillColor, Optional<Color> edgeColor) {
+        this.rectangle = rectangle;
+        this.fillColor = fillColor;
+        this.edgeColor = edgeColor;
+    }
+
+    @Override
+    public Rectangle rectangle() {
+        return rectangle;
+    }
+
+    @Override
+    public Color fillColor() {
+        return fillColor;
+    }
+
+    @Override
+    public Optional<Color> edgeColor() {
+        return edgeColor;
+    }
+}

--- a/immutable-processor/src/test/resources/generated/test/ImmutableEmpty.java
+++ b/immutable-processor/src/test/resources/generated/test/ImmutableEmpty.java
@@ -1,0 +1,10 @@
+package test;
+
+import javax.annotation.processing.Generated;
+
+@Generated("org.example.immutable.processor.ImmutableProcessor")
+class ImmutableEmpty implements Empty {
+
+    ImmutableEmpty() {
+    }
+}

--- a/immutable-processor/src/test/resources/generated/test/ImmutableRectangle.java
+++ b/immutable-processor/src/test/resources/generated/test/ImmutableRectangle.java
@@ -1,0 +1,25 @@
+package test;
+
+import javax.annotation.processing.Generated;
+
+@Generated("org.example.immutable.processor.ImmutableProcessor")
+class ImmutableRectangle implements Rectangle {
+
+    private final double width;
+    private final double height;
+
+    ImmutableRectangle(double width, double height) {
+        this.width = width;
+        this.height = height;
+    }
+
+    @Override
+    public double width() {
+        return width;
+    }
+
+    @Override
+    public double height() {
+        return height;
+    }
+}

--- a/immutable-processor/src/test/resources/test/ColoredRectangle.java
+++ b/immutable-processor/src/test/resources/test/ColoredRectangle.java
@@ -1,0 +1,19 @@
+package test;
+
+import org.example.immutable.Immutable;
+import java.awt.Color;
+import java.util.Optional;
+
+@Immutable
+public interface ColoredRectangle {
+
+    public static ColoredRectangle of(Rectangle rectangle, Color fillColor, Optional<Color> edgeColor) {
+        return null; // Not implemented for testing purposes.
+    }
+
+    Rectangle rectangle();
+
+    Color fillColor();
+
+    Optional<Color> edgeColor();
+}

--- a/immutable-processor/src/test/resources/test/Empty.java
+++ b/immutable-processor/src/test/resources/test/Empty.java
@@ -1,0 +1,11 @@
+package test;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface Empty {
+
+    static Empty of() {
+        return null; // Not implemented for testing purposes.
+    }
+}

--- a/immutable-processor/src/test/resources/test/Rectangle.java
+++ b/immutable-processor/src/test/resources/test/Rectangle.java
@@ -1,0 +1,19 @@
+package test;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface Rectangle {
+
+    static Rectangle of(double width, double height) {
+        return null; // Not implemented for testing purposes.
+    }
+
+    double width();
+
+    double height();
+
+    default double area() {
+        return width() * height();
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,4 @@
 rootProject.name = 'immutable'
 
 include 'immutable-annotations'
+include 'immutable-processor'


### PR DESCRIPTION
main

- Add `ImmutableProcessor`, which currently only implements boilerplate logic.

test

- Add `TestCompiler`, which compiles sources with the processor.
- Add example sources to `test/resources`, plus expected generated sources.
- Add `ImmutableProcessorTest`, which only verifies that the compilation succeeds.