### PR TITLE
base processor infra

### DIFF
--- a/immutable-processor/build.gradle
+++ b/immutable-processor/build.gradle
@@ -6,9 +6,16 @@ plugins {
 dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0.1'
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
+    annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
 
     implementation project(':immutable-annotations')
+    implementation 'com.google.dagger:dagger:2.44.2'
+    implementation 'com.google.guava:guava:31.1-jre'
+    implementation 'javax.inject:javax.inject:1'
 
+    testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
+
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
     testImplementation 'com.google.testing.compile:compile-testing:0.19'
 }
 

--- a/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
@@ -1,0 +1,20 @@
+package org.example.immutable.processor;
+
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.Immutable;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+
+/** Processes interfaces annotated with {@link Immutable}. */
+@ProcessorScope
+final class ImmutableLiteProcessor extends ImmutableBaseLiteProcessor {
+
+    @Inject
+    ImmutableLiteProcessor() {}
+
+    @Override
+    protected void process(TypeElement typeElement) {
+        // TODO: Implement me.
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableProcessor.java
@@ -1,51 +1,40 @@
 package org.example.immutable.processor;
 
 import com.google.auto.service.AutoService;
-import java.util.Set;
-import javax.annotation.processing.Completion;
+import dagger.BindsInstance;
+import dagger.Component;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
-import javax.annotation.processing.RoundEnvironment;
-import javax.lang.model.SourceVersion;
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
 import org.example.immutable.Immutable;
+import org.example.immutable.processor.base.ImmutableBaseProcessor;
+import org.example.immutable.processor.base.LiteProcessor;
+import org.example.immutable.processor.base.ProcessorModule;
+import org.example.immutable.processor.base.ProcessorScope;
 
 /** Processes interfaces annotated with {@link Immutable}. */
 @AutoService(Processor.class)
-public final class ImmutableProcessor implements Processor {
+public final class ImmutableProcessor extends ImmutableBaseProcessor {
 
     @Override
-    public Set<String> getSupportedOptions() {
-        return Set.of();
+    protected LiteProcessor initLiteProcessor(ProcessingEnvironment processingEnv) {
+        ProcessorComponent processorComponent = ProcessorComponent.of(processingEnv);
+        return processorComponent.liteProcessor();
     }
 
-    @Override
-    public Set<String> getSupportedAnnotationTypes() {
-        return Set.of(Immutable.class.getCanonicalName());
-    }
+    @Component(modules = ProcessorModule.class)
+    @ProcessorScope
+    interface ProcessorComponent {
 
-    @Override
-    public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.latestSupported();
-    }
+        static ProcessorComponent of(ProcessingEnvironment processingEnv) {
+            return DaggerImmutableProcessor_ProcessorComponent.factory().create(processingEnv);
+        }
 
-    @Override
-    public void init(ProcessingEnvironment processingEnv) {
-        // TODO: Implement me.
-    }
+        ImmutableLiteProcessor liteProcessor();
 
-    @Override
-    public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        // TODO: Implement me.
-        return false;
-    }
+        @Component.Factory
+        interface Factory {
 
-    @Override
-    public Iterable<? extends Completion> getCompletions(
-            Element element, AnnotationMirror annotationMirror, ExecutableElement executableElement, String s) {
-        return Set.of();
+            ProcessorComponent create(@BindsInstance ProcessingEnvironment processingEnv);
+        }
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessor.java
@@ -1,0 +1,33 @@
+package org.example.immutable.processor.base;
+
+import com.google.common.collect.Iterables;
+import java.util.Set;
+import java.util.stream.Stream;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.Immutable;
+
+/**
+ * Finds all types annotated with {@link Immutable} and processes them.
+ *
+ * <p>Each type is processed by the abstract {@link #process(TypeElement)} method.</p>
+ */
+public abstract class ImmutableBaseLiteProcessor implements LiteProcessor {
+
+    @Override
+    public final void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        ImmutableBaseLiteProcessor.getImmutableTypes(annotations, roundEnv).forEach(this::process);
+    }
+
+    /** Processes a type annotated with {@link Immutable}. */
+    protected abstract void process(TypeElement typeElement);
+
+    /** Gets all types annotated with {@link Immutable}. */
+    private static Stream<TypeElement> getImmutableTypes(
+            Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        TypeElement annotation = Iterables.getOnlyElement(annotations);
+        Set<? extends Element> element = roundEnv.getElementsAnnotatedWith(annotation);
+        return element.stream().map(TypeElement.class::cast);
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseProcessor.java
@@ -1,0 +1,67 @@
+package org.example.immutable.processor.base;
+
+import com.google.auto.service.AutoService;
+import dagger.Component;
+import java.util.Set;
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.Immutable;
+
+/**
+ * Implements boilerplate processing logic for interfaces annotated with {@link Immutable}.
+ *
+ * <p>The core processing logic lives in a {@link LiteProcessor},
+ * which is provided by the abstract {@link #initLiteProcessor(ProcessingEnvironment)} method.
+ * (The {@link Component} for dependency injection will also be created in this method.)</p>
+ *
+ * <p>The full implementation will also need to be annotated with an {@link AutoService} annotation:
+ * {@code @AutoService(Processor.class)}.</p>
+ */
+public abstract class ImmutableBaseProcessor implements Processor {
+
+    private LiteProcessor liteProcessor;
+
+    @Override
+    public final Set<String> getSupportedOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public final Set<String> getSupportedAnnotationTypes() {
+        return Set.of(Immutable.class.getCanonicalName());
+    }
+
+    @Override
+    public final SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public final void init(ProcessingEnvironment processingEnv) {
+        liteProcessor = initLiteProcessor(processingEnv);
+    }
+
+    @Override
+    public final boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (annotations.isEmpty()) {
+            return false;
+        }
+        liteProcessor.process(annotations, roundEnv);
+        return false;
+    }
+
+    @Override
+    public final Iterable<? extends Completion> getCompletions(
+            Element element, AnnotationMirror annotationMirror, ExecutableElement executableElement, String s) {
+        return Set.of();
+    }
+
+    protected abstract LiteProcessor initLiteProcessor(ProcessingEnvironment processingEnv);
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/LiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/LiteProcessor.java
@@ -1,0 +1,26 @@
+package org.example.immutable.processor.base;
+
+import java.util.Set;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Lightweight annotation processor.
+ *
+ * <p>A full {@link Processor} will implement all the boilerplate logic,
+ * and then {@link Processor#process(Set, RoundEnvironment)}
+ * will hand off control to {@link #process(Set, RoundEnvironment)}.</p>
+ */
+public interface LiteProcessor {
+
+    /**
+     * Corresponds to {@link Processor#process(Set, RoundEnvironment)} with a few simplifications:
+     *
+     * <ol>
+     *     <li>The set of annotations is never empty.</li>
+     *     <li>It does not return a value.</li>
+     * </ol>
+     */
+    void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv);
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/ProcessorModule.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/ProcessorModule.java
@@ -1,0 +1,38 @@
+package org.example.immutable.processor.base;
+
+import dagger.Module;
+import dagger.Provides;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/** Provides objects that are part of the {@link ProcessingEnvironment}. */
+@Module
+public interface ProcessorModule {
+
+    @Provides
+    @ProcessorScope
+    static Elements provideElements(ProcessingEnvironment processingEnv) {
+        return processingEnv.getElementUtils();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Types provideTypes(ProcessingEnvironment processingEnv) {
+        return processingEnv.getTypeUtils();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Messager provideMessager(ProcessingEnvironment processingEnv) {
+        return processingEnv.getMessager();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Filer provideFiler(ProcessingEnvironment processingEnv) {
+        return processingEnv.getFiler();
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/ProcessorScope.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/ProcessorScope.java
@@ -1,0 +1,14 @@
+package org.example.immutable.processor.base;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.inject.Scope;
+
+/** Scope for objects whose lifecycle begins with {@link Processor#init(ProcessingEnvironment)}. */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProcessorScope {}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessorTest.java
@@ -1,0 +1,43 @@
+package org.example.immutable.processor.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableBaseLiteProcessorTest {
+
+    @Test
+    public void getQualifiedName_Rectangle() throws Exception {
+        getQualifiedName("test/Rectangle.java", "test.Rectangle");
+    }
+
+    public void getQualifiedName(String sourcePath, String expectedQualifiedName) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        String qualifiedName = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(qualifiedName).isEqualTo(expectedQualifiedName);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(Filer filer) {
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            String qualifiedName = typeElement.getQualifiedName().toString();
+            TestResources.saveObject(filer, typeElement, qualifiedName);
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
@@ -5,14 +5,22 @@ import static com.google.testing.compile.CompilationSubject.assertThat;
 import com.google.testing.compile.Compilation;
 import com.google.testing.compile.Compiler;
 import com.google.testing.compile.JavaFileObjects;
+import dagger.BindsInstance;
+import dagger.Component;
 import java.util.List;
 import java.util.stream.StreamSupport;
+import javax.annotation.processing.ProcessingEnvironment;
 import javax.annotation.processing.Processor;
 import javax.tools.JavaFileObject;
+import org.example.immutable.Immutable;
 import org.example.immutable.processor.ImmutableProcessor;
+import org.example.immutable.processor.base.ImmutableBaseProcessor;
+import org.example.immutable.processor.base.LiteProcessor;
+import org.example.immutable.processor.base.ProcessorModule;
+import org.example.immutable.processor.base.ProcessorScope;
 
 /**
- * Compiles sources with {@link ImmutableProcessor}.
+ * Compiles sources with either {@link ImmutableProcessor} or a custom annotation processor.
  *
  * <p>It checks that the sources compile both without and with the annotation processor.</p>
  */
@@ -23,6 +31,12 @@ public class TestCompiler {
     /** Creates a compiler with {@link ImmutableProcessor}. */
     public static TestCompiler create() {
         Processor processor = new ImmutableProcessor();
+        return new TestCompiler(processor);
+    }
+
+    /** Creates a compiler with {@link ImmutableBaseProcessor} and a custom {@link LiteProcessor}. */
+    public static TestCompiler create(Class<? extends LiteProcessor> liteProcessorClass) {
+        Processor processor = new TestImmutableProcessor(liteProcessorClass);
         return new TestCompiler(processor);
     }
 
@@ -59,5 +73,50 @@ public class TestCompiler {
     private void compileWithoutProcessor(Iterable<JavaFileObject> sourceFiles) {
         Compilation compilation = Compiler.javac().compile(sourceFiles);
         assertThat(compilation).succeededWithoutWarnings();
+    }
+
+    /**
+     * Processes interfaces annotated with {@link Immutable}.
+     *
+     * <p>It uses a custom implementation of {@link LiteProcessor}.</p>
+     */
+    private static final class TestImmutableProcessor extends ImmutableBaseProcessor {
+
+        private final Class<? extends LiteProcessor> liteProcessorClass;
+
+        // Normally, a Processor must provide a public no-arg constructor, but TestCompiler instantiates this directly.
+        TestImmutableProcessor(Class<? extends LiteProcessor> liteProcessorClass) {
+            this.liteProcessorClass = liteProcessorClass;
+        }
+
+        @Override
+        protected LiteProcessor initLiteProcessor(ProcessingEnvironment processingEnv) {
+            TestProcessorComponent processorComponent = TestProcessorComponent.builder()
+                    .processingEnv(processingEnv)
+                    .liteProcessorClass(liteProcessorClass)
+                    .build();
+            return processorComponent.liteProcessor();
+        }
+    }
+
+    @Component(modules = {ProcessorModule.class, TestProcessorModule.class})
+    @ProcessorScope
+    interface TestProcessorComponent {
+
+        static Builder builder() {
+            return DaggerTestCompiler_TestProcessorComponent.builder();
+        }
+
+        LiteProcessor liteProcessor();
+
+        @Component.Builder
+        interface Builder {
+
+            Builder processingEnv(@BindsInstance ProcessingEnvironment processingEnv);
+
+            Builder liteProcessorClass(@BindsInstance Class<? extends LiteProcessor> liteProcessorClass);
+
+            TestProcessorComponent build();
+        }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -1,0 +1,54 @@
+package org.example.immutable.processor.test;
+
+import dagger.Binds;
+import dagger.Component;
+import dagger.MapKey;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.processing.Processor;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessorTest;
+import org.example.immutable.processor.base.LiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+
+/**
+ * Provides all test implementations of {@link LiteProcessor}
+ * as well as the selected implementation, using the {@link LiteProcessor} class as a key.
+ *
+ * <p>The design of this module is slightly convoluted,
+ * but it saves us from writing a separate {@link Component} and {@link Processor}
+ * for each test implementation of {@link LiteProcessor}.</p>
+ */
+@Module
+public interface TestProcessorModule {
+
+    /** Selects a {@link LiteProcessor} from all available test implementations.  */
+    @Provides
+    @ProcessorScope
+    static LiteProcessor provideLiteProcessor(
+            Map<Class<? extends LiteProcessor>, LiteProcessor> liteProcessors, Class<? extends LiteProcessor> key) {
+        LiteProcessor liteProcessor = liteProcessors.get(key);
+        return Objects.requireNonNull(liteProcessor);
+    }
+
+    @MapKey
+    @interface LiteProcessorClassKey {
+
+        Class<? extends LiteProcessor> value();
+    }
+
+    /*
+     * Add test implementations of LiteProcessor below (in import order).
+     */
+
+    // org.example.immutable.processor.base
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(ImmutableBaseLiteProcessorTest.TestLiteProcessor.class)
+    LiteProcessor bindImmutableBaseLiteProcessorTestLiteProcessor(
+            ImmutableBaseLiteProcessorTest.TestLiteProcessor liteProcessor);
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestResources.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestResources.java
@@ -1,0 +1,93 @@
+package org.example.immutable.processor.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.testing.compile.Compilation;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.Writer;
+import java.util.Optional;
+import javax.annotation.processing.Filer;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.tools.FileObject;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+
+/**
+ * Saves Java objects to JSON resource files during annotation processing, and loads those objects as well.
+ *
+ * <p>It assumes that the Java objects can be serialized to and deserialized from JSON.</p>
+ */
+public final class TestResources {
+
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    /**
+     * Saves a corresponding object for the type to a resource file during annotation processing.
+     *
+     * <p>For top-level types with the same name as the source,
+     * the resource path is simply the source path, but with a .json extension.</p>
+     */
+    public static void saveObject(Filer filer, TypeElement typeElement, Object object) {
+        try {
+            FileObject resourceFile = createResourceFile(filer, typeElement);
+            saveObject(resourceFile, object);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Loads an object from a generated resource file.
+     *
+     * <p>It assumes that the resource path is the source path, but with a .json extension.
+     * It can be used for top-level types with the same name as the source.</p>
+     */
+    public static <T> T loadObjectForSource(Compilation compilation, String sourcePath, TypeReference<T> type)
+            throws Exception {
+        String resourcePath = sourcePath.replace(".java", ".json");
+        FileObject resourceFile = getResourceFile(compilation, resourcePath);
+        return loadObject(resourceFile, type);
+    }
+
+    /** Creates a resource file for the type during annotation processing. */
+    private static FileObject createResourceFile(Filer filer, TypeElement typeElement) throws IOException {
+        // This does not work for nested types.
+        PackageElement packageElement = (PackageElement) typeElement.getEnclosingElement();
+        String packageName = packageElement.getQualifiedName().toString();
+        String simpleName = typeElement.getSimpleName().toString();
+        String fileName = String.format("%s.json", simpleName);
+        return filer.createResource(StandardLocation.SOURCE_OUTPUT, packageName, fileName, typeElement);
+    }
+
+    /** Gets a resource file generated during annotation processing. */
+    private static FileObject getResourceFile(Compilation compilation, String resourcePath) {
+        Optional<JavaFileObject> maybeResourceFile =
+                compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, resourcePath);
+        assertThat(maybeResourceFile)
+                .withFailMessage("resource not found: %s", resourcePath)
+                .isPresent();
+        return maybeResourceFile.get();
+    }
+
+    /** Serializes the object to JSON, and writes it to the resource file. */
+    private static void saveObject(FileObject resourceFile, Object object) throws Exception {
+        String serializedObject = mapper.writeValueAsString(object);
+        try (Writer writer = resourceFile.openWriter()) {
+            writer.write(serializedObject);
+        }
+    }
+
+    /** Reads JSON from the resource file, and deserializes it to an object. */
+    private static <T> T loadObject(FileObject resourceFile, TypeReference<T> type) throws Exception {
+        try (Reader reader = resourceFile.openReader(false)) {
+            return mapper.readValue(reader, type);
+        }
+    }
+
+    // static class
+    private TestResources() {}
+}


### PR DESCRIPTION
Overview

- The `LiteProcessor` interface simplifies annotation processing.
- To implement an annotation processor, you only need to extend `ImmutableBaseLiteProcessor`.
- Tests can also extend `ImmutableBaseLiteProcessor` to create a custom annotation processor for testing.

main

- lite processor
  - Add `LiteProcessor` interface.
  - Add `ImmutableBaseLiteProcessor`.
    - It finds all types annotated with `@Immutable`.
    - It uses an abstract `process()` method to process each type.
  - Add `ImmutableLiteProcessor`, which extends `ImmutableBaseLiteProcessor`.
    - It currently is a no-op implementation.
- full processor
  - Add `ImmutableBaseProcessor`.
    - It handles boilerplate processing logic.
    - It hands off core processing logic to a `LiteProcessor`.
    - It uses an abstract `initLiteProcessor()` method to provide the lite processor.
  - Change `ImmutableProcessor` to extend `ImmutableBaseProcessor`.
    - It uses dependency injection (i.e., Dagger) to create an `ImmutableLiteProcessor`.

test

- Add a `TestCompiler.create()` overload that uses a custom annotation processor.
  - Each test implementation of `LiteProcessor` also has to be added to `TestProcessorModule`.
- Add `TestResources`.
  - It can save Java objects to resource files during annotation processing.
  - It can load those objects as well so that a test can verify them.
- Add `ImmutableBaseLiteProcessorTest`, which verifies the qualified name of the processed type.