### PR TITLE
intermediate model

### DIFF
--- a/immutable-processor/build.gradle
+++ b/immutable-processor/build.gradle
@@ -5,17 +5,21 @@ plugins {
 
 dependencies {
     compileOnly 'com.google.auto.service:auto-service-annotations:1.0.1'
+    compileOnly 'org.immutables:value-annotations:2.9.2'
     annotationProcessor 'com.google.auto.service:auto-service:1.0.1'
     annotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
+    annotationProcessor 'org.immutables:value:2.9.2'
 
     implementation project(':immutable-annotations')
     implementation 'com.google.dagger:dagger:2.44.2'
     implementation 'com.google.guava:guava:31.1-jre'
     implementation 'javax.inject:javax.inject:1'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 
     testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
 
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.1'
+    testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.1'
     testImplementation 'com.google.testing.compile:compile-testing:0.19'
 }
 

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
@@ -1,0 +1,57 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+import org.immutables.value.Value;
+
+/**
+ * Implementation of an immutable interface.
+ *
+ * <p>If an {@link ImmutableImpl} can be instantiated, then its source can be generated without errors.</p>
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableImmutableImpl.class)
+@JsonDeserialize(as = ImmutableImmutableImpl.class)
+public interface ImmutableImpl {
+
+    static ImmutableImpl of(ImmutableType type, List<ImmutableMember> members) {
+        return ImmutableImmutableImpl.builder().type(type).members(members).build();
+    }
+
+    /** Gets the type of the implementing class. */
+    ImmutableType type();
+
+    /** Gets the immutable members. */
+    List<ImmutableMember> members();
+
+    /** Gets the name of the source. */
+    @Value.Derived
+    @JsonIgnore
+    default String sourceName() {
+        return type().rawImplType().qualifiedName();
+    }
+
+    /** Gets the type qualifier for all top-level types referenced in the implementation. */
+    @Value.Derived
+    @JsonIgnore
+    default TypeQualifier typeQualifier() {
+        // Get the package information for the source.
+        String packageName = type().rawImplType().packageName();
+        Set<String> packageTypes = type().packageTypes();
+
+        // Get the type variables and types referenced in the source.
+        Set<String> typeVars = Set.copyOf(type().typeVars());
+        Set<TopLevelType> referencedTypes = new HashSet<>();
+        referencedTypes.addAll(Set.of(TopLevelType.of(Generated.class), TopLevelType.of(Override.class)));
+        referencedTypes.addAll(type().implType().args());
+        referencedTypes.addAll(type().interfaceType().args());
+        members().forEach(member -> referencedTypes.addAll(member.type().args()));
+
+        return TypeQualifier.of(packageName, packageTypes, typeVars, referencedTypes);
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableMember.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableMember.java
@@ -1,0 +1,22 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+/** Member of an immutable class: a method without parameters, backed by a corresponding field. */
+@Value.Immutable
+@JsonSerialize(as = ImmutableImmutableMember.class)
+@JsonDeserialize(as = ImmutableImmutableMember.class)
+public interface ImmutableMember {
+
+    static ImmutableMember of(String name, NamedType type) {
+        return ImmutableImmutableMember.builder().name(name).type(type).build();
+    }
+
+    /** Gets the name of the member. */
+    String name();
+
+    /** Gets the type of the member. */
+    NamedType type();
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableType.java
@@ -1,0 +1,48 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Set;
+import org.immutables.value.Value;
+
+/**
+ * Class type implementing an immutable interface.
+ *
+ * <p>The class has the same package as the interface.</p>
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableImmutableType.class)
+@JsonDeserialize(as = ImmutableImmutableType.class)
+public interface ImmutableType {
+
+    static ImmutableType of(
+            TopLevelType rawImplType,
+            Set<String> packageTypes,
+            List<String> typeVars,
+            NamedType implType,
+            NamedType interfaceType) {
+        return ImmutableImmutableType.builder()
+                .rawImplType(rawImplType)
+                .packageTypes(packageTypes)
+                .typeVars(typeVars)
+                .implType(implType)
+                .interfaceType(interfaceType)
+                .build();
+    }
+
+    /** Gets the raw type of the implementing class. */
+    TopLevelType rawImplType();
+
+    /** Gets the simple name of all top-level types in the type's package .*/
+    Set<String> packageTypes();
+
+    /** Gets the type variables for generic types, or an empty list for non-generic types. */
+    List<String> typeVars();
+
+    /** Gets the type of the implementing class. */
+    NamedType implType();
+
+    /** Gets the type of the implemented interface. */
+    NamedType interfaceType();
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/NamedType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/NamedType.java
@@ -1,0 +1,85 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.immutables.value.Value;
+
+/**
+ * Type that is referenced by name in the source.
+ *
+ * <p>For top-level types that are referenced, either the simple name or the fully qualified name can be used.</p>
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableNamedType.class)
+@JsonDeserialize(as = ImmutableNamedType.class)
+public interface NamedType {
+
+    static NamedType of(String nameFormat, List<TopLevelType> args) {
+        return ImmutableNamedType.builder().nameFormat(nameFormat).args(args).build();
+    }
+
+    static NamedType of(String nameFormat, TopLevelType... args) {
+        return of(nameFormat, List.of(args));
+    }
+
+    static NamedType of(TopLevelType topLevelType) {
+        return of("%s", topLevelType);
+    }
+
+    /** Concatenates two types into a single type. */
+    static NamedType concat(NamedType type1, NamedType type2) {
+        return join(List.of(type1, type2), "", "", "");
+    }
+
+    /** Joins a list of types into a single type. */
+    static NamedType join(List<NamedType> types, String delimiter, String prefix, String suffix) {
+        String nameFormat =
+                types.stream().map(NamedType::nameFormat).collect(Collectors.joining(delimiter, prefix, suffix));
+        List<TopLevelType> args =
+                types.stream().map(NamedType::args).flatMap(List::stream).toList();
+        return NamedType.of(nameFormat, args);
+    }
+
+    /** Gets the format string for the type's name, using "%s" for top-level type arguments. */
+    String nameFormat();
+
+    /** Gets the top-level type arguments for the format string. */
+    List<TopLevelType> args();
+
+    /** Gets the type's name, using simple names only. */
+    @Value.Derived
+    @JsonIgnore
+    default String name() {
+        Object[] nameArgs = args().stream().map(TopLevelType::simpleName).toArray(String[]::new);
+        return String.format(nameFormat(), nameArgs);
+    }
+
+    /** Gets the type's name, using fully qualified names for the provided top-level types. */
+    default String name(Set<TopLevelType> qualifiedTypes) {
+        if (qualifiedTypes.isEmpty()) {
+            return name();
+        }
+
+        Object[] nameArgs = args().stream()
+                .map(type -> qualifiedTypes.contains(type) ? type.qualifiedName() : type.simpleName())
+                .toArray(String[]::new);
+        return String.format(nameFormat(), nameArgs);
+    }
+
+    /** Gets the type's name for a declaration, using fully qualified names for the provided top-level types. */
+    default String declarationName(Set<TopLevelType> qualifiedTypes) {
+        if (qualifiedTypes.isEmpty()) {
+            return name();
+        }
+
+        TopLevelType rawType = args().get(0);
+        String nameFormat =
+                String.format("%s%s", rawType.simpleName(), nameFormat().substring(2));
+        NamedType declarationType = NamedType.of(nameFormat, args().subList(1, args().size()));
+        return declarationType.name(qualifiedTypes);
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/TopLevelType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/TopLevelType.java
@@ -1,0 +1,37 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+/** Raw top-level type. */
+@Value.Immutable
+@JsonSerialize(as = ImmutableTopLevelType.class)
+@JsonDeserialize(as = ImmutableTopLevelType.class)
+public interface TopLevelType {
+
+    static TopLevelType of(String packageName, String simpleName) {
+        return ImmutableTopLevelType.builder()
+                .packageName(packageName)
+                .simpleName(simpleName)
+                .build();
+    }
+
+    static TopLevelType of(Class<?> clazz) {
+        return of(clazz.getPackageName(), clazz.getSimpleName());
+    }
+
+    /** Gets the fully qualified name of the type's package. */
+    String packageName();
+
+    /** Gets the simple name of the type. */
+    String simpleName();
+
+    @Value.Derived
+    @JsonIgnore
+    /** Gets the fully qualified name of the type. */
+    default String qualifiedName() {
+        return String.format("%s.%s", packageName(), simpleName());
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/TypeQualifier.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/TypeQualifier.java
@@ -1,0 +1,81 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.immutables.value.Value;
+
+/** Ensures that all top-level types are either imported or referenced via their fully qualified name. */
+@Value.Immutable
+@JsonSerialize(as = ImmutableTypeQualifier.class)
+@JsonDeserialize(as = ImmutableTypeQualifier.class)
+public interface TypeQualifier {
+
+    static TypeQualifier of(
+            String packageName, Set<String> packageTypes, Set<String> typeVars, Set<TopLevelType> referencedTypes) {
+        return ImmutableTypeQualifier.builder()
+                .packageName(packageName)
+                .packageTypes(packageTypes)
+                .typeVars(typeVars)
+                .referencedTypes(referencedTypes)
+                .build();
+    }
+
+    /** Gets the package name of the source. */
+    String packageName();
+
+    /** Gets the simple name of all top-level types in the source's package. */
+    Set<String> packageTypes();
+
+    /** Gets the type variables that are referenced in the source. */
+    Set<String> typeVars();
+
+    /** Gets all top-level types that are referenced in the source. */
+    Set<TopLevelType> referencedTypes();
+
+    /** Gets all top-level types that require an import statement, in sorted order. */
+    @Value.Derived
+    @JsonIgnore
+    default Set<TopLevelType> importedTypes() {
+        Set<String> implicitlyImportedPackages = Set.of("java.lang", packageName());
+        return referencedTypes().stream()
+                .filter(type -> !implicitlyImportedPackages.contains(type.packageName()))
+                .filter(type -> !qualifiedTypes().contains(type))
+                .sorted(Comparator.comparing(TopLevelType::qualifiedName))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
+    /** Gets all top-level types that must be referenced via their fully qualified name. */
+    @Value.Derived
+    @JsonIgnore
+    default Set<TopLevelType> qualifiedTypes() {
+        // If multiple types have the same simple name, qualify the types.
+        // Types in the source's package are not qualified for this reason, however.
+        Map<String, Set<TopLevelType>> typesBySimpleName =
+                referencedTypes().stream().collect(Collectors.groupingBy(TopLevelType::simpleName, Collectors.toSet()));
+        Stream<TopLevelType> typeConflicts = typesBySimpleName.values().stream()
+                .filter(topLevelTypes -> topLevelTypes.size() > 1)
+                .flatMap(Set::stream)
+                .filter(type -> !type.packageName().equals(packageName()));
+
+        // If a type's simple name conflicts with a type variable, qualify the type.
+        Stream<TopLevelType> typeVarConflicts =
+                referencedTypes().stream().filter(type -> typeVars().contains(type.simpleName()));
+
+        // Check that referenced types in the "java.lang" package do not conflict with a type in the source package.
+        // The types in the source's package do not need to be referenced for a conflict to exist.
+        Stream<TopLevelType> javaLangConflicts = referencedTypes().stream()
+                .filter(type -> type.packageName().equals("java.lang"))
+                .filter(type -> packageTypes().contains(type.simpleName()));
+
+        return Stream.of(typeConflicts, typeVarConflicts, javaLangConflicts)
+                .flatMap(s -> s)
+                .collect(Collectors.toSet());
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
@@ -1,0 +1,46 @@
+package org.example.immutable.processor.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.awt.Color;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.Generated;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableImplTest {
+
+    @Test
+    public void sourceName() {
+        ImmutableImpl impl = TestImmutableImpls.rectangle();
+        assertThat(impl.sourceName()).isEqualTo("test.ImmutableRectangle");
+    }
+
+    @Test
+    public void typeQualifier() {
+        TypeQualifier typeQualifier = TestImmutableImpls.coloredRectangle().typeQualifier();
+        TypeQualifier expectedTypeQualifier = TypeQualifier.of(
+                "test",
+                Set.of("Rectangle", "ColoredRectangle", "Empty"),
+                Set.of(),
+                Set.of(
+                        TopLevelType.of(Generated.class),
+                        TopLevelType.of(Override.class),
+                        TopLevelType.of("test", "ImmutableColoredRectangle"),
+                        TopLevelType.of("test", "ColoredRectangle"),
+                        TopLevelType.of("test", "Rectangle"),
+                        TopLevelType.of(Color.class),
+                        TopLevelType.of(Optional.class)));
+        assertThat(typeQualifier).isEqualTo(expectedTypeQualifier);
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        ImmutableImpl impl = TestImmutableImpls.rectangle();
+        TestResources.serializeAndDeserialize(impl, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableMemberTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableMemberTest.java
@@ -1,0 +1,16 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableMemberTest {
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        ImmutableMember member = TestImmutableImpls.rectangle().members().get(0);
+        TestResources.serializeAndDeserialize(member, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableTypeTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableTypeTest.java
@@ -1,0 +1,16 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableTypeTest {
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        ImmutableType type = TestImmutableImpls.rectangle().type();
+        TestResources.serializeAndDeserialize(type, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/NamedTypeTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/NamedTypeTest.java
@@ -1,0 +1,73 @@
+package org.example.immutable.processor.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class NamedTypeTest {
+
+    @Test
+    public void of_TopLevelType() {
+        NamedType type = NamedType.of(TopLevelType.of(String.class));
+        assertThat(type.nameFormat()).isEqualTo("%s");
+        assertThat(type.args()).containsExactly(TopLevelType.of(String.class));
+    }
+
+    @Test
+    public void concat() {
+        NamedType type1 = NamedType.of("Map");
+        NamedType type2 = NamedType.of("<%s, %s>", TopLevelType.of(String.class), TopLevelType.of(Integer.class));
+        NamedType type = NamedType.concat(type1, type2);
+        assertThat(type.nameFormat()).isEqualTo("Map<%s, %s>");
+        assertThat(type.args()).containsExactly(TopLevelType.of(String.class), TopLevelType.of(Integer.class));
+    }
+
+    @Test
+    public void join() {
+        List<NamedType> types =
+                List.of(NamedType.of(TopLevelType.of(String.class)), NamedType.of(TopLevelType.of(Integer.class)));
+        NamedType type = NamedType.join(types, ", ", "<", ">");
+        assertThat(type.nameFormat()).isEqualTo("<%s, %s>");
+        assertThat(type.args()).containsExactly(TopLevelType.of(String.class), TopLevelType.of(Integer.class));
+    }
+
+    @Test
+    public void name_WithoutQualifiedTypes() {
+        NamedType type = NamedType.of(
+                "%s.Entry<%s, %s>",
+                TopLevelType.of(Map.class), TopLevelType.of(String.class), TopLevelType.of(String.class));
+        assertThat(type.name()).isEqualTo("Map.Entry<String, String>");
+    }
+
+    @Test
+    public void name_WithQualifiedTypes() {
+        NamedType type = NamedType.of(
+                "%s.Entry<%s, %s>",
+                TopLevelType.of(Map.class), TopLevelType.of(String.class), TopLevelType.of(String.class));
+        Set<TopLevelType> qualifiedTypes = Set.of(TopLevelType.of(String.class));
+        String name = type.name(qualifiedTypes);
+        assertThat(name).isEqualTo("Map.Entry<java.lang.String, java.lang.String>");
+    }
+
+    @Test
+    public void declarationName() {
+        TopLevelType rawType = TopLevelType.of("test", "T");
+        NamedType type = NamedType.of("%s<T extends %s>", rawType, rawType);
+        Set<TopLevelType> qualifiedTypes = Set.of(rawType);
+        String declarationName = type.declarationName(qualifiedTypes);
+        assertThat(declarationName).isEqualTo("T<T extends test.T>");
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        NamedType type = TestImmutableImpls.rectangle().type().implType();
+        TestResources.serializeAndDeserialize(type, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/TopLevelTypeTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/TopLevelTypeTest.java
@@ -1,0 +1,31 @@
+package org.example.immutable.processor.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class TopLevelTypeTest {
+
+    @Test
+    public void of_Class() {
+        TopLevelType type = TopLevelType.of(String.class);
+        assertThat(type.packageName()).isEqualTo("java.lang");
+        assertThat(type.simpleName()).isEqualTo("String");
+    }
+
+    @Test
+    public void qualifiedName() {
+        TopLevelType type = TestImmutableImpls.rectangle().type().rawImplType();
+        assertThat(type.qualifiedName()).isEqualTo("test.ImmutableRectangle");
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        TopLevelType type = TestImmutableImpls.rectangle().type().rawImplType();
+        TestResources.serializeAndDeserialize(type, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/TypeQualifierTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/TypeQualifierTest.java
@@ -1,0 +1,99 @@
+package org.example.immutable.processor.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import javax.annotation.processing.Generated;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class TypeQualifierTest {
+
+    @Test
+    public void importedTypes_Order() {
+        TypeQualifier typeQualifier = TypeQualifier.of(
+                "test",
+                Set.of(),
+                Set.of(),
+                Set.of(TopLevelType.of(Generated.class), TopLevelType.of(List.class), TopLevelType.of(Callable.class)));
+        assertThat(typeQualifier.importedTypes())
+                .containsExactly(
+                        TopLevelType.of(List.class), TopLevelType.of(Callable.class), TopLevelType.of(Generated.class));
+    }
+
+    @Test
+    public void importedTypes_DoNotImportImplicitlyImportedTypes() {
+        TypeQualifier typeQualifier = TypeQualifier.of(
+                "test",
+                Set.of(),
+                Set.of(),
+                Set.of(
+                        TopLevelType.of(String.class),
+                        TopLevelType.of(List.class),
+                        TopLevelType.of("test", "Rectangle")));
+        assertThat(typeQualifier.importedTypes()).containsExactlyInAnyOrder(TopLevelType.of(List.class));
+    }
+
+    @Test
+    public void importedTypes_DoNotImportQualifiedTypes() {
+        TypeQualifier typeQualifier = TypeQualifier.of(
+                "test",
+                Set.of(),
+                Set.of(),
+                Set.of(TopLevelType.of("test.sub1", "Type"), TopLevelType.of("test.sub2", "Type")));
+        assertThat(typeQualifier.importedTypes()).isEmpty();
+    }
+
+    @Test
+    public void qualifiedTypes_TypeConflictsWithTypeNotInSourcePackage() {
+        TypeQualifier typeQualifier = TypeQualifier.of(
+                "test",
+                Set.of(),
+                Set.of(),
+                Set.of(
+                        TopLevelType.of(List.class),
+                        TopLevelType.of("test.sub1", "Type"),
+                        TopLevelType.of("test.sub2", "Type")));
+        assertThat(typeQualifier.qualifiedTypes())
+                .containsExactlyInAnyOrder(TopLevelType.of("test.sub1", "Type"), TopLevelType.of("test.sub2", "Type"));
+    }
+
+    @Test
+    public void qualifiedTypes_TypeConflictsWithTypeInSourcePackage() {
+        TypeQualifier typeQualifier = TypeQualifier.of(
+                "test", Set.of(), Set.of(), Set.of(TopLevelType.of(List.class), TopLevelType.of("test", "List")));
+        assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.of(List.class));
+    }
+
+    @Test
+    public void qualifiedTypes_TypeNotInSourcePackageConflictsWithTypeVariable() {
+        TypeQualifier typeQualifier =
+                TypeQualifier.of("test", Set.of(), Set.of("String"), Set.of(TopLevelType.of(String.class)));
+        assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.of(String.class));
+    }
+
+    @Test
+    public void qualifiedTypes_TypeInSourcePackageConflictsWithTypeVariable() {
+        TypeQualifier typeQualifier =
+                TypeQualifier.of("test", Set.of(), Set.of("T"), Set.of(TopLevelType.of("Type", "T")));
+        assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.of("Type", "T"));
+    }
+
+    @Test
+    public void qualifiedTypes_JavaLangTypeConflictsWithTypeInSourcePackage() {
+        TypeQualifier typeQualifier =
+                TypeQualifier.of("test", Set.of("Override"), Set.of(), Set.of(TopLevelType.of(Override.class)));
+        assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.of(Override.class));
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        TypeQualifier typeQualifier = TestImmutableImpls.coloredRectangle().typeQualifier();
+        TestResources.serializeAndDeserialize(typeQualifier, new TypeReference<>() {});
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestImmutableImpls.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestImmutableImpls.java
@@ -1,0 +1,101 @@
+package org.example.immutable.processor.test;
+
+import java.util.List;
+import java.util.Set;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.model.ImmutableMember;
+import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
+
+/** Creates test {@link ImmutableImpl}'s. */
+public final class TestImmutableImpls {
+
+    private static Set<String> PACKAGE_TYPES = Set.of("Rectangle", "ColoredRectangle", "Empty");
+
+    private static final ImmutableImpl RECTANGLE = createRectangle();
+    private static final ImmutableImpl COLORED_RECTANGLE = createColoredRectangle();
+    private static final ImmutableImpl EMPTY = createEmpty();
+
+    /** Gets the expected {@link ImmutableImpl} for {@code test/Rectangle.java}. */
+    public static ImmutableImpl rectangle() {
+        return RECTANGLE;
+    }
+
+    /** Gets the expected {@link ImmutableImpl} for {@code test/ColoredRectangle.java}. */
+    public static ImmutableImpl coloredRectangle() {
+        return COLORED_RECTANGLE;
+    }
+
+    /** Gets the expected {@link ImmutableImpl} for {@code test/Empty.java}. */
+    public static ImmutableImpl empty() {
+        return EMPTY;
+    }
+
+    private static ImmutableImpl createRectangle() {
+        // Create the type.
+        TopLevelType rawImplType = TopLevelType.of("test", "ImmutableRectangle");
+        TopLevelType rawInterfaceType = TopLevelType.of("test", "Rectangle");
+
+        List<String> typeVars = List.of();
+        NamedType implType = NamedType.of(rawImplType);
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+
+        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+
+        // Create the members.
+        NamedType doubleType = NamedType.of("double");
+
+        ImmutableMember width = ImmutableMember.of("width", doubleType);
+        ImmutableMember height = ImmutableMember.of("height", doubleType);
+
+        // Create the implementation.
+        return ImmutableImpl.of(type, List.of(width, height));
+    }
+
+    private static ImmutableImpl createColoredRectangle() {
+        // Create the type.
+        TopLevelType rawImplType = TopLevelType.of("test", "ImmutableColoredRectangle");
+        TopLevelType rawInterfaceType = TopLevelType.of("test", "ColoredRectangle");
+
+        List<String> typeVars = List.of();
+        NamedType implType = NamedType.of(rawImplType);
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+
+        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+
+        // Create the members.
+        TopLevelType rectangleImport = TopLevelType.of("test", "Rectangle");
+        TopLevelType colorImport = TopLevelType.of("java.awt", "Color");
+        TopLevelType optionalImport = TopLevelType.of("java.util", "Optional");
+
+        NamedType rectangleType = NamedType.of(rectangleImport);
+        NamedType colorType = NamedType.of(colorImport);
+        NamedType optionalColorType = NamedType.of("%s<%s>", optionalImport, colorImport);
+
+        ImmutableMember rectangle = ImmutableMember.of("rectangle", rectangleType);
+        ImmutableMember fillColor = ImmutableMember.of("fillColor", colorType);
+        ImmutableMember edgeColor = ImmutableMember.of("edgeColor", optionalColorType);
+
+        // Create the implementation.
+        return ImmutableImpl.of(type, List.of(rectangle, fillColor, edgeColor));
+    }
+
+    private static ImmutableImpl createEmpty() {
+        // Create the type.
+        TopLevelType rawImplType = TopLevelType.of("test", "ImmutableEmpty");
+        TopLevelType rawInterfaceType = TopLevelType.of("test", "Empty");
+
+        List<String> typeVars = List.of();
+        NamedType implType = NamedType.of(rawImplType);
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+
+        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+
+        // Create the implementation.
+        return ImmutableImpl.of(type, List.of());
+    }
+
+    // static class
+    private TestImmutableImpls() {}
+}


### PR DESCRIPTION
Overview

- This sets up a two-stage pipeline:
  1. Convert the `TypeElement` to an `ImmutableImpl`.
  1. Convert the `ImmutableImpl` to source code. 
- `ImmutableImpl` is a pure type that models the immutable implementation.
  - It can also be serialized to and deserialized from JSON. 

main

- Add `ImmutableImpl` and other model types.

test

- Add a test template to `TestResources` that does a round trip of serialization and deserialization.
- Add `TestImmutableImpls`, which creates the expected `ImmutableImpl`'s for the example sources.
  - The `ImmutableImpl` can be used as the expected value when testing the first stage.
  - The `ImmutableImpl` can also be used as the starting point when testing the second stage.
- Add tests for `ImmutableImpl` and other model types.
  - Verify specialized factory methods.
  - Verify derived fields.
  - Verify the round trip of serialization and deserialization.


