### PR TITLE
generate source from ImmutableImpl

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/generator/ImmutableGenerator.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/generator/ImmutableGenerator.java
@@ -1,0 +1,33 @@
+package org.example.immutable.processor.generator;
+
+import java.io.IOException;
+import java.io.Writer;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.tools.JavaFileObject;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableImpl;
+
+/** Generates source code for {@link ImmutableImpl}'s. */
+@ProcessorScope
+public final class ImmutableGenerator {
+
+    private final Filer filer;
+
+    @Inject
+    ImmutableGenerator(Filer filer) {
+        this.filer = filer;
+    }
+
+    /** Generates the source code for the provided {@link ImmutableImpl}. */
+    public void generateSource(ImmutableImpl impl) {
+        try {
+            JavaFileObject sourceFile = filer.createSourceFile(impl.sourceName());
+            try (Writer writer = sourceFile.openWriter()) {
+                SourceWriter.writeSource(writer, impl);
+            }
+        } catch (IOException e) {
+            throw new RuntimeException("unexpected IO exception writing source", e);
+        }
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/generator/SourceWriter.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/generator/SourceWriter.java
@@ -1,0 +1,134 @@
+package org.example.immutable.processor.generator;
+
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.processing.Generated;
+import org.example.immutable.processor.ImmutableProcessor;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.model.ImmutableMember;
+import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
+
+/** Writes the source code for an {@link ImmutableImpl}, using an open {@link Writer}. */
+final class SourceWriter {
+
+    private static final NamedType GENERATED_TYPE = NamedType.of(TopLevelType.of(Generated.class));
+    private static final NamedType OVERRIDE_TYPE = NamedType.of(TopLevelType.of(Override.class));
+    private static final String PROCESSOR_QUALIFIED_NAME = ImmutableProcessor.class.getCanonicalName();
+
+    private final PrintWriter writer;
+    private final ImmutableImpl impl;
+    private final Set<TopLevelType> qualifiedTypes;
+
+    /** Writes the source code for the provided {@link ImmutableImpl}. */
+    public static void writeSource(Writer writer, ImmutableImpl impl) {
+        try (PrintWriter printWriter = new PrintWriter(writer)) {
+            SourceWriter sourceWriter = new SourceWriter(printWriter, impl);
+            sourceWriter.writeSource();
+        }
+    }
+
+    private SourceWriter(PrintWriter writer, ImmutableImpl impl) {
+        this.writer = writer;
+        this.impl = impl;
+        qualifiedTypes = impl.typeQualifier().qualifiedTypes();
+    }
+
+    /** Writes the source code. */
+    private void writeSource() {
+        writePackage();
+        writeImports();
+        writeClassHeader();
+        if (impl.members().isEmpty()) {
+            writeConstructor();
+            writeClassFooter();
+            return;
+        }
+        writeFields();
+        writeConstructor();
+        writeMethods();
+        writeClassFooter();
+    }
+
+    /** Writes the package statement. */
+    private void writePackage() {
+        writer.format("package %s;", impl.type().rawImplType().packageName()).println();
+    }
+
+    /** Writes the import statements. */
+    private void writeImports() {
+        Set<TopLevelType> importedTypes = impl.typeQualifier().importedTypes();
+
+        if (importedTypes.isEmpty()) {
+            return;
+        }
+        writer.println();
+        importedTypes.forEach(
+                type -> writer.format("import %s;", type.qualifiedName()).println());
+    }
+
+    /** Writes the class declaration and the opening curly brace. */
+    private void writeClassHeader() {
+        ImmutableType type = impl.type();
+
+        writer.println();
+        writer.format("@%s(\"%s\")", name(GENERATED_TYPE), PROCESSOR_QUALIFIED_NAME)
+                .println();
+        writer.format("class %s implements %s {", declarationName(type.implType()), name(type.interfaceType()))
+                .println();
+    }
+
+    /** Writes the fields that back the methods. */
+    private void writeFields() {
+        writer.println();
+        for (ImmutableMember member : impl.members()) {
+            writer.format("    private final %s %s;", name(member.type()), member.name())
+                    .println();
+        }
+    }
+
+    /** Writes the sole constructor to initialize all the fields. */
+    private void writeConstructor() {
+        String params = impl.members().stream()
+                .map(member -> String.format("%s %s", name(member.type()), member.name()))
+                .collect(Collectors.joining(", "));
+
+        writer.println();
+        writer.format("    %s(%s) {", impl.type().rawImplType().simpleName(), params)
+                .println();
+        for (ImmutableMember member : impl.members()) {
+            writer.format("        this.%1$s = %1$s;", member.name()).println();
+        }
+        writer.println("    }");
+    }
+
+    /** Writes the methods that implement the interface. */
+    private void writeMethods() {
+        for (ImmutableMember member : impl.members()) {
+            writer.println();
+            writer.format("    @%s", name(OVERRIDE_TYPE)).println();
+            writer.format("    public %s %s() {", name(member.type()), member.name())
+                    .println();
+            writer.format("        return %s;", member.name()).println();
+            writer.println("    }");
+        }
+    }
+
+    /** Writes the closing curly brace for the class. */
+    private void writeClassFooter() {
+        writer.println("}");
+    }
+
+    /** Gets the type's name, qualifying types as appropriate. */
+    private String name(NamedType type) {
+        return type.name(qualifiedTypes);
+    }
+
+    /** Gets the type's name for a declaration, qualifying types as appropriate. */
+    private String declarationName(NamedType type) {
+        return type.declarationName(qualifiedTypes);
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/generator/ImmutableGeneratorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/generator/ImmutableGeneratorTest.java
@@ -1,0 +1,54 @@
+package org.example.immutable.processor.generator;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableGeneratorTest {
+
+    @Test
+    public void generateSource_Rectangle() {
+        generateSource("test/Rectangle.java", "test.ImmutableRectangle", "generated/test/ImmutableRectangle.java");
+    }
+
+    private void generateSource(String sourcePath, String generatedQualifiedName, String expectedGeneratedSourcePath) {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        assertThat(compilation)
+                .generatedSourceFile(generatedQualifiedName)
+                .hasSourceEquivalentTo(JavaFileObjects.forResource(expectedGeneratedSourcePath));
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final ImmutableGenerator generator;
+
+        @Inject
+        TestLiteProcessor(ImmutableGenerator generator) {
+            this.generator = generator;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            loadImmutableImpl(typeElement).ifPresent(generator::generateSource);
+        }
+
+        private Optional<ImmutableImpl> loadImmutableImpl(TypeElement typeElement) {
+            String qualifiedName = typeElement.getQualifiedName().toString();
+            return switch (qualifiedName) {
+                case "test.Rectangle" -> Optional.of(TestImmutableImpls.rectangle());
+                default -> Optional.empty();
+            };
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
@@ -1,0 +1,109 @@
+package org.example.immutable.processor.generator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.io.CharStreams;
+import com.google.testing.compile.JavaFileObjects;
+import java.io.IOException;
+import java.io.Reader;
+import java.io.StringWriter;
+import java.util.List;
+import java.util.Set;
+import javax.tools.JavaFileObject;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.model.ImmutableMember;
+import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.junit.jupiter.api.Test;
+
+public final class SourceWriterTest {
+
+    @Test
+    public void writeSource_Rectangle() throws IOException {
+        writeSource(TestImmutableImpls.rectangle(), "generated/test/ImmutableRectangle.java");
+    }
+
+    @Test
+    public void writeSource_ColoredRectangle() throws IOException {
+        writeSource(TestImmutableImpls.coloredRectangle(), "generated/test/ImmutableColoredRectangle.java");
+    }
+
+    @Test
+    public void writeSource_Empty() throws IOException {
+        writeSource(TestImmutableImpls.empty(), "generated/test/ImmutableEmpty.java");
+    }
+
+    @Test
+    public void writeSource_QualifiedTypes() throws IOException {
+        writeSource(createImpl_QualifiedTypes(), "generated/test/source/ImmutableQualifiedTypes.java");
+    }
+
+    @Test
+    public void writeSource_QualifiedTypesDeclaration() throws IOException {
+        writeSource(
+                createImpl_QualifiedTypesDeclaration(),
+                "generated/test/source/ImmutableQualifiedTypesDeclaration.java");
+    }
+
+    private void writeSource(ImmutableImpl impl, String expectedSourcePath) throws IOException {
+        String source = writeSourceToString(impl);
+        assertThat(source).isEqualTo(loadSource(expectedSourcePath));
+    }
+
+    private static ImmutableImpl createImpl_QualifiedTypes() {
+        // Create the type.
+        TopLevelType rawImplType = TopLevelType.of("test.source", "ImmutableQualifiedTypes");
+        TopLevelType rawInterfaceType = TopLevelType.of("test.source", "QualifiedTypes");
+        Set<String> packageTypes = Set.of("QualifiedTypes", "String", "Generated", "Override");
+
+        List<String> typeVars = List.of();
+        NamedType implType = NamedType.of(rawImplType);
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+
+        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+
+        // Create the members
+        TopLevelType stringPackageImport = TopLevelType.of("test.source", "String");
+        TopLevelType stringImport = TopLevelType.of(String.class);
+        TopLevelType generatedPackageImport = TopLevelType.of("test.source", "Generated");
+
+        ImmutableMember member1 = ImmutableMember.of("member1", NamedType.of(stringPackageImport));
+        ImmutableMember member2 = ImmutableMember.of("member2", NamedType.of(stringImport));
+        ImmutableMember member3 = ImmutableMember.of("member3", NamedType.of(generatedPackageImport));
+
+        // Create the implementation.
+        return ImmutableImpl.of(type, List.of(member1, member2, member3));
+    }
+
+    private static ImmutableImpl createImpl_QualifiedTypesDeclaration() {
+        // Create the type.
+        TopLevelType rawImplType = TopLevelType.of("test.source", "ImmutableQualifiedTypesDeclaration");
+        TopLevelType rawInterfaceType = TopLevelType.of("test.source", "QualifiedTypesDeclaration");
+        Set<String> packageTypes = Set.of("QualifiedTypesDeclaration");
+
+        List<String> typeVars = List.of("ImmutableQualifiedTypesDeclaration");
+        NamedType implType =
+                NamedType.of("%s<ImmutableQualifiedTypesDeclaration extends %s>", rawImplType, rawImplType);
+        NamedType interfaceType = NamedType.of("%s<ImmutableQualifiedTypesDeclaration>", rawInterfaceType);
+
+        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+
+        // Create the implementation.
+        return ImmutableImpl.of(type, List.of());
+    }
+
+    private static String writeSourceToString(ImmutableImpl impl) {
+        StringWriter writer = new StringWriter();
+        SourceWriter.writeSource(writer, impl);
+        return writer.toString();
+    }
+
+    private static String loadSource(String sourcePath) throws IOException {
+        JavaFileObject file = JavaFileObjects.forResource(sourcePath);
+        try (Reader reader = file.openReader(false)) {
+            return CharStreams.toString(reader);
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -12,6 +12,7 @@ import javax.annotation.processing.Processor;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessorTest;
 import org.example.immutable.processor.base.LiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.generator.ImmutableGeneratorTest;
 
 /**
  * Provides all test implementations of {@link LiteProcessor}
@@ -51,4 +52,12 @@ public interface TestProcessorModule {
     @LiteProcessorClassKey(ImmutableBaseLiteProcessorTest.TestLiteProcessor.class)
     LiteProcessor bindImmutableBaseLiteProcessorTestLiteProcessor(
             ImmutableBaseLiteProcessorTest.TestLiteProcessor liteProcessor);
+
+    // org.example.immutable.processor.generator
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(ImmutableGeneratorTest.TestLiteProcessor.class)
+    LiteProcessor bindImmutableGeneratorTestLiteProcessor(ImmutableGeneratorTest.TestLiteProcessor liteProcessor);
 }

--- a/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypes.java
+++ b/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypes.java
@@ -1,0 +1,30 @@
+package test.source;
+
+@javax.annotation.processing.Generated("org.example.immutable.processor.ImmutableProcessor")
+class ImmutableQualifiedTypes implements QualifiedTypes {
+
+    private final String member1;
+    private final java.lang.String member2;
+    private final Generated member3;
+
+    ImmutableQualifiedTypes(String member1, java.lang.String member2, Generated member3) {
+        this.member1 = member1;
+        this.member2 = member2;
+        this.member3 = member3;
+    }
+
+    @java.lang.Override
+    public String member1() {
+        return member1;
+    }
+
+    @java.lang.Override
+    public java.lang.String member2() {
+        return member2;
+    }
+
+    @java.lang.Override
+    public Generated member3() {
+        return member3;
+    }
+}

--- a/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypesDeclaration.java
+++ b/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypesDeclaration.java
@@ -1,0 +1,10 @@
+package test.source;
+
+import javax.annotation.processing.Generated;
+
+@Generated("org.example.immutable.processor.ImmutableProcessor")
+class ImmutableQualifiedTypesDeclaration<ImmutableQualifiedTypesDeclaration extends test.source.ImmutableQualifiedTypesDeclaration> implements QualifiedTypesDeclaration<ImmutableQualifiedTypesDeclaration> {
+
+    ImmutableQualifiedTypesDeclaration() {
+    }
+}


### PR DESCRIPTION
Overview

- This implements the second stage: from `ImmutableImpl` to source code.
- `ImmutableGenerator` is the entry point for the second stage.

main

- Add `SourceWriter`, which does most of the work.
- Add `ImmutableGenerator`, which wraps `SourceWriter` and creates the source file.

test

- Add tests for `SourceWriter`, `ImmutableGenerator`.