### PR TITLE
get methods to implement

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ElementNavigator.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ElementNavigator.java
@@ -1,0 +1,49 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.List;
+import java.util.stream.Stream;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.ElementFilter;
+import javax.lang.model.util.Elements;
+import org.example.immutable.processor.base.ProcessorScope;
+
+/** Navigates immutable types to extract the relevant elements. */
+@ProcessorScope
+final class ElementNavigator {
+
+    private static final String OBJECT_NAME = Object.class.getCanonicalName();
+
+    private final Elements elementUtils;
+
+    @Inject
+    ElementNavigator(Elements elementUtils) {
+        this.elementUtils = elementUtils;
+    }
+
+    /** Gets all methods that must be implemented. */
+    public Stream<ExecutableElement> getMethodsToImplement(TypeElement typeElement) {
+        List<? extends Element> memberElements = elementUtils.getAllMembers(typeElement);
+        List<ExecutableElement> methodElements = ElementFilter.methodsIn(memberElements);
+        return methodElements.stream()
+                .filter(this::isNotBuiltInMethod)
+                .filter(this::isInstanceMethod)
+                .filter(this::isNotDefaultMethod);
+    }
+
+    private boolean isNotBuiltInMethod(ExecutableElement methodElement) {
+        TypeElement typeElement = (TypeElement) methodElement.getEnclosingElement();
+        return !typeElement.getQualifiedName().contentEquals(OBJECT_NAME);
+    }
+
+    private boolean isInstanceMethod(ExecutableElement methodElement) {
+        return !methodElement.getModifiers().contains(Modifier.STATIC);
+    }
+
+    private boolean isNotDefaultMethod(ExecutableElement methodElement) {
+        return !methodElement.getModifiers().contains(Modifier.DEFAULT);
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ElementNavigatorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ElementNavigatorTest.java
@@ -1,0 +1,54 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import java.util.List;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ElementNavigatorTest {
+
+    @Test
+    public void getMethodsToImplement_Rectangle() throws Exception {
+        getMethodsToImplement("test/Rectangle.java", List.of("width", "height"));
+    }
+
+    private void getMethodsToImplement(String sourcePath, List<String> expectedMethodNames) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        List<String> methodNames = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(methodNames).isEqualTo(expectedMethodNames);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final ElementNavigator navigator;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(ElementNavigator navigator, Filer filer) {
+            this.navigator = navigator;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            List<String> methodNames = navigator
+                    .getMethodsToImplement(typeElement)
+                    .map(Element::getSimpleName)
+                    .map(Name::toString)
+                    .toList();
+            TestResources.saveObject(filer, typeElement, methodNames);
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -13,6 +13,7 @@ import org.example.immutable.processor.base.ImmutableBaseLiteProcessorTest;
 import org.example.immutable.processor.base.LiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.generator.ImmutableGeneratorTest;
+import org.example.immutable.processor.modeler.ElementNavigatorTest;
 
 /**
  * Provides all test implementations of {@link LiteProcessor}
@@ -60,4 +61,12 @@ public interface TestProcessorModule {
     @IntoMap
     @LiteProcessorClassKey(ImmutableGeneratorTest.TestLiteProcessor.class)
     LiteProcessor bindImmutableGeneratorTestLiteProcessor(ImmutableGeneratorTest.TestLiteProcessor liteProcessor);
+
+    // org.example.immutable.processor.modeler
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(ElementNavigatorTest.TestLiteProcessor.class)
+    LiteProcessor bindElementNavigatorTestLiteProcessor(ElementNavigatorTest.TestLiteProcessor liteProcessor);
 }


### PR DESCRIPTION
Overview

- `ElementNavigator.getMethodsToImplement()` gets the interface methods that must be implemented.

main

- Add `ElementNavigator`

test

- Add tests for `ElementNavigator`