### PR TITLE
implement Empty.java end-to-end

### DIFF
--- a/immutable-example/build.gradle
+++ b/immutable-example/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+    id 'org.example.immutable.java-conventions'
+    id 'application'
+}
+
+dependencies {
+    compileOnly project(':immutable-annotations')
+    annotationProcessor project(':immutable-processor')
+}
+
+application {
+    mainClass = 'org.example.immutable.example.Main'
+}

--- a/immutable-example/src/main/java/org/example/immutable/example/Empty.java
+++ b/immutable-example/src/main/java/org/example/immutable/example/Empty.java
@@ -1,0 +1,11 @@
+package org.example.immutable.example;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface Empty {
+
+    static Empty of() {
+        return new ImmutableEmpty();
+    }
+}

--- a/immutable-example/src/main/java/org/example/immutable/example/Main.java
+++ b/immutable-example/src/main/java/org/example/immutable/example/Main.java
@@ -1,0 +1,17 @@
+package org.example.immutable.example;
+
+public final class Main {
+
+    public static void main(String[] args) {
+        Empty empty = createImmutableObject();
+        displayImmutableObject(empty);
+    }
+
+    private static Empty createImmutableObject() {
+        return Empty.of();
+    }
+
+    private static void displayImmutableObject(Empty empty) {
+        System.out.println(empty.getClass().getCanonicalName());
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
@@ -5,16 +5,24 @@ import javax.lang.model.element.TypeElement;
 import org.example.immutable.Immutable;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.generator.ImmutableGenerator;
+import org.example.immutable.processor.modeler.ImmutableImpls;
 
 /** Processes interfaces annotated with {@link Immutable}. */
 @ProcessorScope
 final class ImmutableLiteProcessor extends ImmutableBaseLiteProcessor {
 
+    private final ImmutableImpls implFactory;
+    private final ImmutableGenerator generator;
+
     @Inject
-    ImmutableLiteProcessor() {}
+    ImmutableLiteProcessor(ImmutableImpls implFactory, ImmutableGenerator generator) {
+        this.implFactory = implFactory;
+        this.generator = generator;
+    }
 
     @Override
     protected void process(TypeElement typeElement) {
-        // TODO: Implement me.
+        implFactory.create(typeElement).ifPresent(generator::generateSource);
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/TopLevelType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/TopLevelType.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.immutables.value.Value;
 
-/** Raw top-level type. */
+/**
+ * Raw top-level type.
+ *
+ * <p>It can be assumed that the type has a package.</p>
+ */
 @Value.Immutable
 @JsonSerialize(as = ImmutableTopLevelType.class)
 @JsonDeserialize(as = ImmutableTopLevelType.class)

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
@@ -1,0 +1,38 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.model.ImmutableType;
+
+/** Creates {@link ImmutableImpl}'s from {@link TypeElement}'s. */
+@ProcessorScope
+public final class ImmutableImpls {
+
+    private final ImmutableTypes typeFactory;
+    private final ElementNavigator navigator;
+
+    @Inject
+    ImmutableImpls(ImmutableTypes typeFactory, ElementNavigator navigator) {
+        this.typeFactory = typeFactory;
+        this.navigator = navigator;
+    }
+
+    /** Creates an {@link ImmutableImpl}, or empty if validation fails. */
+    public Optional<ImmutableImpl> create(TypeElement typeElement) {
+        // Create and validate the type.
+        ImmutableType type = typeFactory.create(typeElement).get();
+
+        // Create and validate the methods.
+        if (navigator.getMethodsToImplement(typeElement).findAny().isPresent()) {
+            return Optional.empty();
+        }
+
+        // Create the implementation.
+        ImmutableImpl impl = ImmutableImpl.of(type, List.of());
+        return Optional.of(impl);
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
@@ -1,0 +1,68 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.Name;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
+
+/** Creates {@link ImmutableType}'s from {@link TypeElement}'s. */
+@ProcessorScope
+final class ImmutableTypes {
+
+    private final TopLevelTypes typeFactory;
+    private final Elements elementUtils;
+
+    @Inject
+    ImmutableTypes(TopLevelTypes typeFactory, Elements elementUtils) {
+        this.typeFactory = typeFactory;
+        this.elementUtils = elementUtils;
+    }
+
+    /** Creates an {@link ImmutableType}, or empty if validation fails. */
+    public Optional<ImmutableType> create(TypeElement typeElement) {
+        // Create and validate the raw types.
+        TopLevelType rawInterfaceType = createRawInterfaceType(typeElement);
+        TopLevelType rawImplType = createRawImplType(rawInterfaceType);
+        Set<String> packageTypes = createPackageTypes(typeElement);
+
+        // Create and validate the types. Generics are not yet supported.
+        List<String> typeVars = List.of();
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+        NamedType implType = NamedType.of(rawImplType);
+
+        // Create the immutable type.
+        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+        return Optional.of(type);
+    }
+
+    /** Creates a raw interface type from the type element. */
+    private TopLevelType createRawInterfaceType(TypeElement typeElement) {
+        return typeFactory.create(typeElement).get();
+    }
+
+    /** Creates a raw implementation type from the raw interface type. */
+    private TopLevelType createRawImplType(TopLevelType rawInterfaceType) {
+        String simpleImplName = String.format("Immutable%s", rawInterfaceType.simpleName());
+        TopLevelType rawImplType = TopLevelType.of(rawInterfaceType.packageName(), simpleImplName);
+        return rawImplType;
+    }
+
+    /** Creates a list of top-level types in the same package as this type. */
+    private Set<String> createPackageTypes(TypeElement typeElement) {
+        PackageElement packageElement = elementUtils.getPackageOf(typeElement);
+        return packageElement.getEnclosedElements().stream()
+                .map(Element::getSimpleName)
+                .map(Name::toString)
+                .collect(Collectors.toSet());
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/TopLevelTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/TopLevelTypes.java
@@ -1,0 +1,30 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.lang.model.element.PackageElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.TopLevelType;
+
+/** Creates {@link TopLevelType}'s from {@link TypeElement}'s. */
+@ProcessorScope
+final class TopLevelTypes {
+
+    private final Elements elementUtils;
+
+    @Inject
+    TopLevelTypes(Elements elementUtils) {
+        this.elementUtils = elementUtils;
+    }
+
+    /** Creates a {@link TopLevelType}, or empty if validation fails. */
+    public Optional<TopLevelType> create(TypeElement typeElement) {
+        PackageElement packageElement = elementUtils.getPackageOf(typeElement);
+        String packageName = packageElement.getQualifiedName().toString();
+        String simpleName = typeElement.getSimpleName().toString();
+        TopLevelType type = TopLevelType.of(packageName, simpleName);
+        return Optional.of(type);
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
@@ -1,9 +1,25 @@
 package org.example.immutable.processor;
 
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.JavaFileObjects;
 import org.example.immutable.processor.test.TestCompiler;
 import org.junit.jupiter.api.Test;
 
 public final class ImmutableProcessorTest {
+
+    @Test
+    public void compile_Empty() {
+        compile("test/Empty.java", "test.ImmutableEmpty", "generated/test/ImmutableEmpty.java");
+    }
+
+    private void compile(String sourcePath, String generatedQualifiedName, String expectedGeneratedSourcePath) {
+        Compilation compilation = TestCompiler.create().compile(sourcePath);
+        assertThat(compilation)
+                .generatedSourceFile(generatedQualifiedName)
+                .hasSourceEquivalentTo(JavaFileObjects.forResource(expectedGeneratedSourcePath));
+    }
 
     @Test
     public void compileWithoutVerifyingSource_Rectangle() {
@@ -13,11 +29,6 @@ public final class ImmutableProcessorTest {
     @Test
     public void compileWithoutVerifyingSource_ColoredRectangle() {
         compileWithoutVerifyingSource("test/ColoredRectangle.java");
-    }
-
-    @Test
-    public void compileWithoutVerifyingSource_Empty() {
-        compileWithoutVerifyingSource("test/Empty.java");
     }
 
     private void compileWithoutVerifyingSource(String sourcePath) {

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
@@ -1,0 +1,48 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableImplsTest {
+
+    @Test
+    public void create_Empty() throws Exception {
+        create("test/Empty.java", TestImmutableImpls.empty());
+    }
+
+    private void create(String sourcePath, ImmutableImpl expectedImpl) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        ImmutableImpl impl = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(impl).isEqualTo(expectedImpl);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final ImmutableImpls implFactory;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(ImmutableImpls implFactory, Filer filer) {
+            this.implFactory = implFactory;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            implFactory.create(typeElement).ifPresent(impl -> TestResources.saveObject(filer, typeElement, impl));
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
@@ -1,0 +1,68 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestImmutableImpls;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class ImmutableTypesTest {
+
+    @Test
+    public void create_Rectangle() throws Exception {
+        create("test/Rectangle.java", TestImmutableImpls.rectangle().type());
+    }
+
+    @Test
+    public void create_Interface() throws Exception {
+        TopLevelType rawImplType = TopLevelType.of("test.type", "ImmutableInterface");
+        TopLevelType rawInterfaceType = TopLevelType.of("test.type", "Interface");
+        List<String> typeVars = List.of();
+        NamedType implType = NamedType.of(rawImplType);
+        NamedType interfaceType = NamedType.of(rawInterfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        create("test/type/Interface.java", expectedType);
+    }
+
+    private void create(String sourcePath, ImmutableType expectedType) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        ImmutableType type = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(normalizeType(type)).isEqualTo(normalizeType(expectedType));
+    }
+
+    /** Empties the package types for comparison purposes. */
+    private ImmutableType normalizeType(ImmutableType type) {
+        return ImmutableType.of(type.rawImplType(), Set.of(), type.typeVars(), type.implType(), type.interfaceType());
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final ImmutableTypes typeFactory;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(ImmutableTypes types, Filer filer) {
+            this.typeFactory = types;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            typeFactory.create(typeElement).ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/TopLevelTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/TopLevelTypesTest.java
@@ -1,0 +1,48 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.TypeElement;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.TopLevelType;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class TopLevelTypesTest {
+
+    @Test
+    public void create_Rectangle() throws Exception {
+        TopLevelType expectedType = TopLevelType.of("test", "Rectangle");
+        create("test/Rectangle.java", expectedType);
+    }
+
+    private void create(String sourcePath, TopLevelType expectedType) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        TopLevelType type = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(type).isEqualTo(expectedType);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final TopLevelTypes typeFactory;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(TopLevelTypes typeFactory, Filer filer) {
+            this.typeFactory = typeFactory;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            typeFactory.create(typeElement).ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -14,6 +14,9 @@ import org.example.immutable.processor.base.LiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.generator.ImmutableGeneratorTest;
 import org.example.immutable.processor.modeler.ElementNavigatorTest;
+import org.example.immutable.processor.modeler.ImmutableImplsTest;
+import org.example.immutable.processor.modeler.ImmutableTypesTest;
+import org.example.immutable.processor.modeler.TopLevelTypesTest;
 
 /**
  * Provides all test implementations of {@link LiteProcessor}
@@ -69,4 +72,22 @@ public interface TestProcessorModule {
     @IntoMap
     @LiteProcessorClassKey(ElementNavigatorTest.TestLiteProcessor.class)
     LiteProcessor bindElementNavigatorTestLiteProcessor(ElementNavigatorTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(ImmutableImplsTest.TestLiteProcessor.class)
+    LiteProcessor bindImmutableImplsTestLiteProcessor(ImmutableImplsTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(ImmutableTypesTest.TestLiteProcessor.class)
+    LiteProcessor bindImmutableTypesTestLiteProcessor(ImmutableTypesTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(TopLevelTypesTest.TestLiteProcessor.class)
+    LiteProcessor bindTopLevelTypesTestLiteProcessor(TopLevelTypesTest.TestLiteProcessor liteProcessor);
 }

--- a/immutable-processor/src/test/resources/test/type/Interface.java
+++ b/immutable-processor/src/test/resources/test/type/Interface.java
@@ -1,0 +1,6 @@
+package test.type;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface Interface {}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'immutable'
 
 include 'immutable-annotations'
+include 'immutable-example'
 include 'immutable-processor'


### PR DESCRIPTION
Overview

- `ImmutableProcessor` can generate code for `Empty.java`.
- It does not yet support interfaces with methods, generic interfaces, or nested interfaces.

main

- Add factory classes `ImmutableImpls` (and `ImmutableTypes`, `TopLevelTypes`).
  - Interaces with methods, generic interfaces, and nested interfaces are not yet supported.
  - No validation is performed, except for returning `Optional.empty()` for interfaces without methods.
- Implement `ImmutableLiteProcessor`.
- Add `immutable-example` project w/ `Empty` class.

test

- Add tests for `ImmutableImpls`, `ImmutableTypes`, `TopLevelTypes`.
  - No error cases are tested.
- Verify `Empty.java` end-to-end.