### PR TITLE
add error infrastructure

### DIFF
--- a/immutable-processor/build.gradle
+++ b/immutable-processor/build.gradle
@@ -16,7 +16,9 @@ dependencies {
     implementation 'javax.inject:javax.inject:1'
     implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
 
+    testCompileOnly 'org.immutables:value-annotations:2.9.2'
     testAnnotationProcessor 'com.google.dagger:dagger-compiler:2.44.2'
+    testAnnotationProcessor 'org.immutables:value-processor:2.9.2'
 
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-guava:2.14.1'
     testImplementation 'com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.14.1'

--- a/immutable-processor/src/main/java/org/example/immutable/processor/error/Errors.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/error/Errors.java
@@ -1,0 +1,76 @@
+package org.example.immutable.processor.error;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import javax.annotation.processing.Messager;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
+import org.example.immutable.processor.base.ProcessorScope;
+
+/**
+ * Reports diagnostic errors, which result in compilation errors.
+ *
+ * <p>It also tracks errors, which allows processing to continue for non-fatal errors.</p>
+ */
+@ProcessorScope
+public final class Errors {
+
+    private final Messager messager;
+    private final Set<Tracker> errorTrackers = new HashSet<>();
+
+    @Inject
+    Errors(Messager messager) {
+        this.messager = messager;
+    }
+
+    /** Reports an error, returning false. */
+    public boolean error(String message, Element element) {
+        return error(message, m -> messager.printMessage(Diagnostic.Kind.ERROR, m, element));
+    }
+
+    /** Reports an error, returning false. */
+    public boolean error(String message) {
+        return error(message, m -> messager.printMessage(Diagnostic.Kind.ERROR, m));
+    }
+
+    /** Reports an error, returning false. */
+    private boolean error(String message, Consumer<String> messagePrinter) {
+        String annotatedMessage = String.format("[@Immutable] %s", message);
+        messagePrinter.accept(annotatedMessage);
+        errorTrackers.forEach(Tracker::reportError);
+        return false;
+    }
+
+    /** Creates an error tracker. */
+    public Tracker createErrorTracker() {
+        return new Tracker();
+    }
+
+    /** Tracks errors, converting the final result to empty if an error occurred. */
+    public final class Tracker implements AutoCloseable {
+
+        private boolean validates = true;
+
+        private Tracker() {
+            errorTrackers.add(this);
+        }
+
+        /** Checks that no errors occurred, returning empty otherwise. */
+        public <T> Optional<T> checkNoErrors(T result) {
+            return validates ? Optional.of(result) : Optional.empty();
+        }
+
+        @Override
+        public void close() {
+            errorTrackers.remove(this);
+        }
+
+        /** Reports an error to the tracker. */
+        private void reportError() {
+            validates = false;
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/ImmutableProcessorTest.java
@@ -22,16 +22,16 @@ public final class ImmutableProcessorTest {
     }
 
     @Test
-    public void compileWithoutVerifyingSource_Rectangle() {
-        compileWithoutVerifyingSource("test/Rectangle.java");
+    public void unsupported_Rectangle() {
+        error("test/Rectangle.java");
     }
 
     @Test
-    public void compileWithoutVerifyingSource_ColoredRectangle() {
-        compileWithoutVerifyingSource("test/ColoredRectangle.java");
+    public void unsupported_ColoredRectangle() {
+        error("test/ColoredRectangle.java");
     }
 
-    private void compileWithoutVerifyingSource(String sourcePath) {
-        TestCompiler.create().compile(sourcePath);
+    private void error(String sourcePath) {
+        TestCompiler.create().expectingCompilationFailure().compile(sourcePath);
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/error/ErrorsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/error/ErrorsTest.java
@@ -1,0 +1,76 @@
+package org.example.immutable.processor.error;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.annotation.processing.Messager;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.Element;
+import javax.tools.Diagnostic;
+import org.junit.jupiter.api.Test;
+
+public class ErrorsTest {
+
+    @Test
+    public void reportError() {
+        MockMessager messager = new MockMessager();
+        Errors errorReporter = new Errors(messager);
+        errorReporter.error("error");
+        assertThat(messager.getMessage()).isEqualTo("[@Immutable] error");
+    }
+
+    @Test
+    public void trackErrors() {
+        Errors errorReporter = new Errors(new MockMessager());
+        try (Errors.Tracker errorTracker = errorReporter.createErrorTracker()) {
+            Object result = new Object();
+            assertThat(errorTracker.checkNoErrors(result)).isPresent();
+            errorReporter.error("error");
+            assertThat(errorTracker.checkNoErrors(result)).isEmpty();
+        }
+    }
+
+    /** Stores the last error message. */
+    private static final class MockMessager implements Messager {
+
+        private String message = "";
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence charSequence) {
+            storeErrorMessage(kind, charSequence);
+        }
+
+        @Override
+        public void printMessage(Diagnostic.Kind kind, CharSequence charSequence, Element element) {
+            storeErrorMessage(kind, charSequence);
+        }
+
+        @Override
+        public void printMessage(
+                Diagnostic.Kind kind, CharSequence charSequence, Element element, AnnotationMirror annotationMirror) {
+            storeErrorMessage(kind, charSequence);
+        }
+
+        @Override
+        public void printMessage(
+                Diagnostic.Kind kind,
+                CharSequence charSequence,
+                Element element,
+                AnnotationMirror annotationMirror,
+                AnnotationValue annotationValue) {
+            storeErrorMessage(kind, charSequence);
+        }
+
+        public String getMessage() {
+            return message;
+        }
+
+        private void storeErrorMessage(Diagnostic.Kind kind, CharSequence charSequence) {
+            if (kind != Diagnostic.Kind.ERROR) {
+                return;
+            }
+
+            message = charSequence.toString();
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
@@ -10,6 +10,8 @@ import javax.lang.model.element.TypeElement;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.ImmutableImpl;
+import org.example.immutable.processor.test.CompilationError;
+import org.example.immutable.processor.test.CompilationErrorsSubject;
 import org.example.immutable.processor.test.TestCompiler;
 import org.example.immutable.processor.test.TestImmutableImpls;
 import org.example.immutable.processor.test.TestResources;
@@ -26,6 +28,23 @@ public final class ImmutableImplsTest {
         Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
         ImmutableImpl impl = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
         assertThat(impl).isEqualTo(expectedImpl);
+    }
+
+    @Test
+    public void unsupported_Rectangle() {
+        error("test/Rectangle.java", CompilationError.of(6, "[@Immutable] methods are not supported"));
+    }
+
+    @Test
+    public void unsupported_ColoredRectangle() {
+        error("test/ColoredRectangle.java", CompilationError.of(8, "[@Immutable] methods are not supported"));
+    }
+
+    private void error(String sourcePath, CompilationError... expectedErrors) {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .compile(sourcePath);
+        CompilationErrorsSubject.assertThat(compilation.errors()).containsExactlyInAnyOrder(expectedErrors);
     }
 
     @ProcessorScope

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/CompilationError.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/CompilationError.java
@@ -1,0 +1,19 @@
+package org.example.immutable.processor.test;
+
+import org.immutables.value.Value;
+
+/** Unique compilation error, identified by the line number and the message. */
+@Value.Immutable
+public interface CompilationError {
+
+    static CompilationError of(long lineNumber, String message) {
+        return ImmutableCompilationError.builder()
+                .lineNumber(lineNumber)
+                .message(message)
+                .build();
+    }
+
+    long lineNumber();
+
+    String message();
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/CompilationErrorsSubject.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/CompilationErrorsSubject.java
@@ -1,0 +1,39 @@
+package org.example.immutable.processor.test;
+
+import com.google.testing.compile.Compilation;
+import java.util.List;
+import java.util.Locale;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.ListAssert;
+
+/** Provides assertions for the errors returned by {@link Compilation#errors()}. */
+public final class CompilationErrorsSubject {
+
+    private final ListAssert<CompilationError> assertThat;
+
+    public static CompilationErrorsSubject assertThat(List<Diagnostic<? extends JavaFileObject>> diagnosticErrors) {
+        return new CompilationErrorsSubject(diagnosticErrors);
+    }
+
+    private CompilationErrorsSubject(List<Diagnostic<? extends JavaFileObject>> diagnosticErrors) {
+        List<CompilationError> errors =
+                diagnosticErrors.stream().map(CompilationErrorsSubject::toError).toList();
+        assertThat = Assertions.assertThat(errors);
+    }
+
+    /** Asserts that the errors contains the provided errors. */
+    public void contains(CompilationError... expectedErrors) {
+        assertThat.contains(expectedErrors);
+    }
+
+    /** Asserts that the errors contains exactly the provided errors in any order. */
+    public void containsExactlyInAnyOrder(CompilationError... expectedErrors) {
+        assertThat.containsExactlyInAnyOrder(expectedErrors);
+    }
+
+    private static CompilationError toError(Diagnostic<? extends JavaFileObject> diagnosticError) {
+        return CompilationError.of(diagnosticError.getLineNumber(), diagnosticError.getMessage(Locale.US));
+    }
+}


### PR DESCRIPTION
Overview

- The processor now has infrastructure to generate (and verify) compilation errors.

main

- Add `Errors`, which can be used to report and track errors.
- Change `ImmutableImpls` to report an error for methods without interfaces (not yet supported).

test

- Add tests for `Errors`.
- Add `CompilationError`, `CompilationErrorsSubject` to verify the contents of compilation errors.
- Modify tests for `ImmutableImpls`, `ImmutableProcessor` to verify new errors.