### PR TITLE
check for type errors, unsupported types

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/ImmutableLiteProcessor.java
@@ -1,10 +1,13 @@
 package org.example.immutable.processor;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import javax.inject.Inject;
 import javax.lang.model.element.TypeElement;
 import org.example.immutable.Immutable;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.error.Errors;
 import org.example.immutable.processor.generator.ImmutableGenerator;
 import org.example.immutable.processor.modeler.ImmutableImpls;
 
@@ -14,15 +17,33 @@ final class ImmutableLiteProcessor extends ImmutableBaseLiteProcessor {
 
     private final ImmutableImpls implFactory;
     private final ImmutableGenerator generator;
+    private final Errors errorReporter;
 
     @Inject
-    ImmutableLiteProcessor(ImmutableImpls implFactory, ImmutableGenerator generator) {
+    ImmutableLiteProcessor(ImmutableImpls implFactory, ImmutableGenerator generator, Errors errorReporter) {
         this.implFactory = implFactory;
         this.generator = generator;
+        this.errorReporter = errorReporter;
     }
 
     @Override
     protected void process(TypeElement typeElement) {
-        implFactory.create(typeElement).ifPresent(generator::generateSource);
+        try {
+            implFactory.create(typeElement).ifPresent(generator::generateSource);
+        } catch (RuntimeException e) {
+            String message = createErrorMessage(e, typeElement);
+            errorReporter.error(message);
+        }
+    }
+
+    /** Create the error message for an unexpected exception while processing the type. */
+    private String createErrorMessage(RuntimeException e, TypeElement typeElement) {
+        StringWriter messageWriter = new StringWriter();
+        PrintWriter printWriter = new PrintWriter(messageWriter);
+        printWriter
+                .format("unexpected exception processing %s", typeElement.getQualifiedName())
+                .println();
+        e.printStackTrace(printWriter);
+        return messageWriter.toString();
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
@@ -2,16 +2,22 @@ package org.example.immutable.processor.modeler;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import javax.inject.Inject;
 import javax.lang.model.element.TypeElement;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.error.Errors;
 import org.example.immutable.processor.model.ImmutableImpl;
 import org.example.immutable.processor.model.ImmutableType;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.model.TopLevelType;
 
 /** Creates {@link ImmutableImpl}'s from {@link TypeElement}'s. */
 @ProcessorScope
 public final class ImmutableImpls {
+
+    private static final ImmutableType ERROR_TYPE =
+            ImmutableType.of(TopLevelType.of("?", "?"), Set.of(), List.of(), NamedType.of("?"), NamedType.of("?"));
 
     private final ImmutableTypes typeFactory;
     private final ElementNavigator navigator;
@@ -26,17 +32,17 @@ public final class ImmutableImpls {
 
     /** Creates an {@link ImmutableImpl}, or empty if validation fails. */
     public Optional<ImmutableImpl> create(TypeElement typeElement) {
-        // Create and validate the type.
-        ImmutableType type = typeFactory.create(typeElement).get();
+        try (Errors.Tracker errorTracker = errorReporter.createErrorTracker()) {
+            // Create and validate the type.
+            ImmutableType type = typeFactory.create(typeElement).orElse(ERROR_TYPE);
 
-        // Create and validate the methods.
-        if (!checkDoesNotHaveMethods(typeElement)) {
-            return Optional.empty();
+            // Create and validate the methods.
+            checkDoesNotHaveMethods(typeElement);
+
+            // Create the implementation.
+            ImmutableImpl impl = ImmutableImpl.of(type, List.of());
+            return errorTracker.checkNoErrors(impl);
         }
-
-        // Create the implementation.
-        ImmutableImpl impl = ImmutableImpl.of(type, List.of());
-        return Optional.of(impl);
     }
 
     private boolean checkDoesNotHaveMethods(TypeElement typeElement) {

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
@@ -6,11 +6,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.error.Errors;
 import org.example.immutable.processor.model.ImmutableType;
 import org.example.immutable.processor.model.NamedType;
 import org.example.immutable.processor.model.TopLevelType;
@@ -20,40 +22,55 @@ import org.example.immutable.processor.model.TopLevelType;
 final class ImmutableTypes {
 
     private final TopLevelTypes typeFactory;
+    private final Errors errorReporter;
     private final Elements elementUtils;
 
     @Inject
-    ImmutableTypes(TopLevelTypes typeFactory, Elements elementUtils) {
+    ImmutableTypes(TopLevelTypes typeFactory, Errors errorReporter, Elements elementUtils) {
         this.typeFactory = typeFactory;
+        this.errorReporter = errorReporter;
         this.elementUtils = elementUtils;
     }
 
     /** Creates an {@link ImmutableType}, or empty if validation fails. */
     public Optional<ImmutableType> create(TypeElement typeElement) {
         // Create and validate the raw types.
-        TopLevelType rawInterfaceType = createRawInterfaceType(typeElement);
-        TopLevelType rawImplType = createRawImplType(rawInterfaceType);
-        Set<String> packageTypes = createPackageTypes(typeElement);
+        try (Errors.Tracker errorTracker = errorReporter.createErrorTracker()) {
+            Optional<TopLevelType> maybeRawInterfaceType = createRawInterfaceType(typeElement);
+            if (maybeRawInterfaceType.isEmpty()) {
+                return Optional.empty();
+            }
+            TopLevelType rawInterfaceType = maybeRawInterfaceType.get();
 
-        // Create and validate the types. Generics are not yet supported.
-        List<String> typeVars = List.of();
-        NamedType interfaceType = NamedType.of(rawInterfaceType);
-        NamedType implType = NamedType.of(rawImplType);
+            TopLevelType rawImplType = createRawImplType(rawInterfaceType, typeElement);
+            Set<String> packageTypes = createPackageTypes(typeElement);
 
-        // Create the immutable type.
-        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
-        return Optional.of(type);
+            // Create and validate the types. Generics are not yet supported.
+            checkDoesNotHaveTypeParameters(typeElement);
+            List<String> typeVars = List.of();
+            NamedType interfaceType = NamedType.of(rawInterfaceType);
+            NamedType implType = NamedType.of(rawImplType);
+
+            // Create the immutable type.
+            ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+            return errorTracker.checkNoErrors(type);
+        }
     }
 
     /** Creates a raw interface type from the type element. */
-    private TopLevelType createRawInterfaceType(TypeElement typeElement) {
-        return typeFactory.create(typeElement).get();
+    private Optional<TopLevelType> createRawInterfaceType(TypeElement typeElement) {
+        if (!checkIsInterface(typeElement) || !checkIsTopLevelInterface(typeElement)) {
+            return Optional.empty();
+        }
+
+        return typeFactory.create(typeElement, typeElement);
     }
 
     /** Creates a raw implementation type from the raw interface type. */
-    private TopLevelType createRawImplType(TopLevelType rawInterfaceType) {
+    private TopLevelType createRawImplType(TopLevelType rawInterfaceType, TypeElement sourceElement) {
         String simpleImplName = String.format("Immutable%s", rawInterfaceType.simpleName());
         TopLevelType rawImplType = TopLevelType.of(rawInterfaceType.packageName(), simpleImplName);
+        checkImplTypeDoesNotExist(rawImplType, sourceElement);
         return rawImplType;
     }
 
@@ -64,5 +81,34 @@ final class ImmutableTypes {
                 .map(Element::getSimpleName)
                 .map(Name::toString)
                 .collect(Collectors.toSet());
+    }
+
+    private boolean checkIsInterface(TypeElement typeElement) {
+        return !typeElement.getKind().isInterface()
+                ? errorReporter.error("type must be an interface", typeElement)
+                : true;
+    }
+
+    private boolean checkIsTopLevelInterface(TypeElement typeElement) {
+        return (typeElement.getEnclosingElement().getKind() != ElementKind.PACKAGE)
+                ? errorReporter.error("nested interfaces are not supported", typeElement)
+                : true;
+    }
+
+    /** Checks that the implementation type to be generated does not already exist. */
+    private void checkImplTypeDoesNotExist(TopLevelType rawImplType, Element sourceElement) {
+        String qualifiedName = rawImplType.qualifiedName();
+        if (elementUtils.getTypeElement(qualifiedName) == null) {
+            return;
+        }
+
+        String message = String.format("implementation type already exists: %s", qualifiedName);
+        errorReporter.error(message, sourceElement);
+    }
+
+    private boolean checkDoesNotHaveTypeParameters(TypeElement typeElement) {
+        return !typeElement.getTypeParameters().isEmpty()
+                ? errorReporter.error("generic interfaces are not supported", typeElement)
+                : true;
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/TopLevelTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/TopLevelTypes.java
@@ -2,29 +2,54 @@ package org.example.immutable.processor.modeler;
 
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.error.Errors;
 import org.example.immutable.processor.model.TopLevelType;
 
-/** Creates {@link TopLevelType}'s from {@link TypeElement}'s. */
+/**
+ * Creates {@link TopLevelType}'s from {@link TypeElement}'s.
+ *
+ * <p>The source {@link Element} is also provided for error reporting purposes.</p>
+ */
 @ProcessorScope
 final class TopLevelTypes {
 
+    private final Errors errorReporter;
     private final Elements elementUtils;
 
     @Inject
-    TopLevelTypes(Elements elementUtils) {
+    TopLevelTypes(Errors errorReporter, Elements elementUtils) {
+        this.errorReporter = errorReporter;
         this.elementUtils = elementUtils;
     }
 
     /** Creates a {@link TopLevelType}, or empty if validation fails. */
-    public Optional<TopLevelType> create(TypeElement typeElement) {
+    public Optional<TopLevelType> create(TypeElement typeElement, Element sourceElement) {
+        if (!checkHasPackage(typeElement, sourceElement) || !checkIsTopLevelType(typeElement, sourceElement)) {
+            return Optional.empty();
+        }
+
         PackageElement packageElement = elementUtils.getPackageOf(typeElement);
         String packageName = packageElement.getQualifiedName().toString();
         String simpleName = typeElement.getSimpleName().toString();
         TopLevelType type = TopLevelType.of(packageName, simpleName);
         return Optional.of(type);
+    }
+
+    private boolean checkHasPackage(TypeElement typeElement, Element sourceElement) {
+        return elementUtils.getPackageOf(typeElement).isUnnamed()
+                ? errorReporter.error("type must have a package", sourceElement)
+                : true;
+    }
+
+    private boolean checkIsTopLevelType(TypeElement typeElement, Element sourceElement) {
+        return (typeElement.getEnclosingElement().getKind() != ElementKind.PACKAGE)
+                ? errorReporter.error("precondition: type is not a top-level type", sourceElement)
+                : true;
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
@@ -1,6 +1,7 @@
 package org.example.immutable.processor.modeler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.immutable.processor.test.CompilationErrorsSubject.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.testing.compile.Compilation;
@@ -11,7 +12,6 @@ import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.ImmutableImpl;
 import org.example.immutable.processor.test.CompilationError;
-import org.example.immutable.processor.test.CompilationErrorsSubject;
 import org.example.immutable.processor.test.TestCompiler;
 import org.example.immutable.processor.test.TestImmutableImpls;
 import org.example.immutable.processor.test.TestResources;
@@ -40,11 +40,17 @@ public final class ImmutableImplsTest {
         error("test/ColoredRectangle.java", CompilationError.of(8, "[@Immutable] methods are not supported"));
     }
 
+    @Test
+    public void error_ImmutableType() {
+        CompilationError expectedError = CompilationError.of(6, "[@Immutable] type must be an interface");
+        error("test/type/error/Class.java", expectedError);
+    }
+
     private void error(String sourcePath, CompilationError... expectedErrors) {
         Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
                 .expectingCompilationFailure()
                 .compile(sourcePath);
-        CompilationErrorsSubject.assertThat(compilation.errors()).containsExactlyInAnyOrder(expectedErrors);
+        assertThat(compilation.errors()).containsExactlyInAnyOrder(expectedErrors);
     }
 
     @ProcessorScope

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/TopLevelTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/TopLevelTypesTest.java
@@ -1,6 +1,7 @@
 package org.example.immutable.processor.modeler;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.example.immutable.processor.test.CompilationErrorsSubject.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.testing.compile.Compilation;
@@ -10,6 +11,7 @@ import javax.lang.model.element.TypeElement;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.TopLevelType;
+import org.example.immutable.processor.test.CompilationError;
 import org.example.immutable.processor.test.TestCompiler;
 import org.example.immutable.processor.test.TestResources;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,27 @@ public final class TopLevelTypesTest {
         assertThat(type).isEqualTo(expectedType);
     }
 
+    @Test
+    public void error_DoesNotHavePackage() {
+        error(
+                "test/type/error/InterfaceWithoutPackage.java",
+                CompilationError.of(4, "[@Immutable] type must have a package"));
+    }
+
+    @Test
+    public void preconditionFailure_IsNotTopLevelType() {
+        error(
+                "test/type/unsupported/InterfaceNested.java",
+                CompilationError.of(8, "[@Immutable] precondition: type is not a top-level type"));
+    }
+
+    private void error(String sourcePath, CompilationError expectedError) {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .compile(sourcePath);
+        assertThat(compilation.errors()).containsExactlyInAnyOrder(expectedError);
+    }
+
     @ProcessorScope
     public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
 
@@ -42,7 +65,9 @@ public final class TopLevelTypesTest {
 
         @Override
         protected void process(TypeElement typeElement) {
-            typeFactory.create(typeElement).ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
+            typeFactory
+                    .create(typeElement, typeElement)
+                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
         }
     }
 }

--- a/immutable-processor/src/test/resources/test/type/error/Class.java
+++ b/immutable-processor/src/test/resources/test/type/error/Class.java
@@ -1,0 +1,6 @@
+package test.type.error;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public class Class {}

--- a/immutable-processor/src/test/resources/test/type/error/InterfaceNestedWithImpl.java
+++ b/immutable-processor/src/test/resources/test/type/error/InterfaceNestedWithImpl.java
@@ -1,0 +1,12 @@
+package test.type.error;
+
+import org.example.immutable.Immutable;
+
+public interface InterfaceNestedWithImpl {
+
+    @Immutable
+    interface Inner {}
+}
+
+@Immutable
+interface InterfaceNestedWithImpl_Inner {}

--- a/immutable-processor/src/test/resources/test/type/error/InterfaceWithImpl.java
+++ b/immutable-processor/src/test/resources/test/type/error/InterfaceWithImpl.java
@@ -1,0 +1,8 @@
+package test.type.error;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface InterfaceWithImpl {}
+
+class ImmutableInterfaceWithImpl {}

--- a/immutable-processor/src/test/resources/test/type/error/InterfaceWithoutPackage.java
+++ b/immutable-processor/src/test/resources/test/type/error/InterfaceWithoutPackage.java
@@ -1,0 +1,4 @@
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface InterfaceWithoutPackage {}

--- a/immutable-processor/src/test/resources/test/type/unsupported/InterfaceGeneric.java
+++ b/immutable-processor/src/test/resources/test/type/unsupported/InterfaceGeneric.java
@@ -1,0 +1,6 @@
+package test.type;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface InterfaceGeneric<T, U> {}

--- a/immutable-processor/src/test/resources/test/type/unsupported/InterfaceGenericBounds.java
+++ b/immutable-processor/src/test/resources/test/type/unsupported/InterfaceGenericBounds.java
@@ -1,0 +1,8 @@
+package test.type;
+
+import org.example.immutable.Immutable;
+
+import java.util.concurrent.Callable;
+
+@Immutable
+public interface InterfaceGenericBounds<T extends Runnable & Callable<Void>> {}

--- a/immutable-processor/src/test/resources/test/type/unsupported/InterfaceNested.java
+++ b/immutable-processor/src/test/resources/test/type/unsupported/InterfaceNested.java
@@ -1,0 +1,9 @@
+package test.type;
+
+import org.example.immutable.Immutable;
+
+public interface InterfaceNested {
+
+    @Immutable
+    interface Inner {}
+}


### PR DESCRIPTION
Overview

- For the `TypeElement`, compilation errors are generated for both legitimate errors and unsupported types.

main

- Add error checks to `ImmutableImpls`, `ImmutableTypes`, `TopLevelTypes`.
- Add catch-all error reporting to `ImmutableLiteProcessor`.

test

- Add tests for errors and unsupported cases for `ImmutableImpls`, `ImmutableTypes`, `TopLevelTypes`.
- Add basic error test for `ImmutableProcessor`.
- Add test to `ImmutableProcessor` that all sources in `test/type` compile with the processor.