### PR TITLE
add NamedTypes

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/NamedTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/NamedTypes.java
@@ -1,0 +1,145 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.type.UnionType;
+import javax.lang.model.type.WildcardType;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.error.Errors;
+import org.example.immutable.processor.model.NamedType;
+
+/**
+ * Creates {@link NamedType}'s from {@link TypeMirror}'s.
+ *
+ * <p>The source {@link Element} is also provided for error reporting purposes.</p>
+ *
+ * <p>It supports the following types:</p>
+ * <ol>
+ *     <li>the type declaration: both the implementing class and the implemented interface</li>
+ *     <li>the return type of a getter method (and also the type of the backing field)</li>
+ * </ol>
+ */
+@ProcessorScope
+final class NamedTypes {
+
+    private static final NamedType ERROR_TYPE = NamedType.of("?");
+
+    private final Errors errorReporter;
+
+    @Inject
+    NamedTypes(Errors errorReporter) {
+        this.errorReporter = errorReporter;
+    }
+
+    /** Creates an {@link NamedType}, or empty if validation fails. */
+    public Optional<NamedType> create(TypeMirror type, Element sourceElement) {
+        try (Errors.Tracker errorTracker = errorReporter.createErrorTracker()) {
+            ElementTypeVisitor typeVisitor = new ElementTypeVisitor(sourceElement);
+            NamedType typeModel = type.accept(typeVisitor, null);
+            return errorTracker.checkNoErrors(typeModel);
+        }
+    }
+
+    /** Recursively constructs the {@link NamedType}. */
+    private class ElementTypeVisitor implements TypeVisitor<NamedType, Void> {
+
+        private final Element sourceElement;
+
+        ElementTypeVisitor(Element sourceElement) {
+            this.sourceElement = sourceElement;
+        }
+
+        @Override
+        public NamedType visit(TypeMirror type, Void unused) {
+            return error("unexpected: type");
+        }
+
+        @Override
+        public NamedType visitPrimitive(PrimitiveType primitiveType, Void unused) {
+            return NamedType.of(primitiveType.toString());
+        }
+
+        @Override
+        public NamedType visitNull(NullType nullType, Void unused) {
+            // Null types are only used for the expression "null".
+            return error("unexpected: null type");
+        }
+
+        @Override
+        public NamedType visitArray(ArrayType arrayType, Void unused) {
+            NamedType componentTypeModel = accept(arrayType.getComponentType());
+            String nameFormat = String.format("%s[]", componentTypeModel.nameFormat());
+            return NamedType.of(nameFormat, componentTypeModel.args());
+        }
+
+        @Override
+        public NamedType visitDeclared(DeclaredType declaredType, Void unused) {
+            return error("declared types are not supported");
+        }
+
+        @Override
+        public NamedType visitError(ErrorType errorType, Void unused) {
+            return error("type failed to compile");
+        }
+
+        @Override
+        public NamedType visitTypeVariable(TypeVariable typeVariable, Void unused) {
+            return NamedType.of(typeVariable.toString());
+        }
+
+        @Override
+        public NamedType visitWildcard(WildcardType wildcardType, Void unused) {
+            return error("wildcards are not supported");
+        }
+
+        @Override
+        public NamedType visitExecutable(ExecutableType executableType, Void unused) {
+            // Executable types are unexpected for type declarations or return types.
+            return error("unexpected: executable type");
+        }
+
+        @Override
+        public NamedType visitNoType(NoType noType, Void unused) {
+            return error("void type not allowed");
+        }
+
+        @Override
+        public NamedType visitUnknown(TypeMirror type, Void unused) {
+            return error("unexpected: unknown type");
+        }
+
+        @Override
+        public NamedType visitUnion(UnionType unionType, Void unused) {
+            // Union types are only used in catch statements.
+            return error("unexpected: union type");
+        }
+
+        @Override
+        public NamedType visitIntersection(IntersectionType intersectionType, Void unused) {
+            // Type parameter bounds are represented as a list of types, not as a type which could be an intersection.
+            return error("unexpected: intersection type");
+        }
+
+        private NamedType accept(TypeMirror type) {
+            return type.accept(this, null);
+        }
+
+        /** Reports an error, returning the error type. */
+        private NamedType error(String message) {
+            errorReporter.error(message, sourceElement);
+            return ERROR_TYPE;
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/NamedTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/NamedTypesTest.java
@@ -1,0 +1,156 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.NamedType;
+import org.example.immutable.processor.test.CompilationError;
+import org.example.immutable.processor.test.CompilationErrorsSubject;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestResources;
+import org.junit.jupiter.api.Test;
+
+public final class NamedTypesTest {
+
+    @Test
+    public void create_TypeArray() throws Exception {
+        NamedType expectedType = NamedType.of("int[][]");
+        create("test/method/TypeArray.java", expectedType);
+    }
+
+    @Test
+    public void create_TypePrimitive() throws Exception {
+        NamedType expectedType = NamedType.of("int");
+        create("test/method/TypePrimitive.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeVariable() throws Exception {
+        NamedType expectedType = NamedType.of("T");
+        create("test/method/TypeVariable.java", expectedType);
+    }
+
+    private void create(String sourcePath, NamedType expectedType) throws Exception {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
+        NamedType type = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(type).isEqualTo(expectedType);
+    }
+
+    @Test
+    public void unsupported_TypeDeclared() {
+        error(
+                "test/method/unsupported/TypeDeclared.java",
+                CompilationError.of(8, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeDeclaredGeneric() {
+        error(
+                "test/method/unsupported/TypeDeclaredGeneric.java",
+                CompilationError.of(9, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeDeclaredNested() {
+        error(
+                "test/method/unsupported/TypeDeclaredNested.java",
+                CompilationError.of(8, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeDeclaredNestedGenericInstance() {
+        error(
+                "test/method/unsupported/TypeDeclaredNestedGenericInstance.java",
+                CompilationError.of(8, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeDeclaredNestedGenericStatic() {
+        error(
+                "test/method/unsupported/TypeDeclaredNestedGenericStatic.java",
+                CompilationError.of(9, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeDeclaredPathological() {
+        error(
+                "test/method/unsupported/TypeDeclaredPathological.java",
+                CompilationError.of(8, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeWildcard() {
+        error(
+                "test/method/unsupported/TypeWildcard.java",
+                CompilationError.of(9, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeWildcardExtends() {
+        error(
+                "test/method/unsupported/TypeWildcardExtends.java",
+                CompilationError.of(9, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void unsupported_TypeWildcardSuper() {
+        error(
+                "test/method/unsupported/TypeWildcardSuper.java",
+                CompilationError.of(9, "[@Immutable] declared types are not supported"));
+    }
+
+    @Test
+    public void error_TypeError() {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .expectingCompilationFailureWithoutProcessor()
+                .compile("test/method/error/TypeError.java");
+        CompilationErrorsSubject.assertThat(compilation.errors())
+                .contains(CompilationError.of(8, "[@Immutable] type failed to compile"));
+    }
+
+    @Test
+    public void error_TypeVoid() {
+        error("test/method/error/TypeVoid.java", CompilationError.of(8, "[@Immutable] void type not allowed"));
+    }
+
+    private void error(String sourcePath, CompilationError expectedError) {
+        Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .compile(sourcePath);
+        CompilationErrorsSubject.assertThat(compilation.errors()).containsExactlyInAnyOrder(expectedError);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final NamedTypes typeFactory;
+        private final ElementNavigator navigator;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(NamedTypes types, ElementNavigator navigator, Filer filer) {
+            this.typeFactory = types;
+            this.navigator = navigator;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            ExecutableElement sourceElement =
+                    navigator.getMethodsToImplement(typeElement).findFirst().get();
+            TypeMirror returnType = sourceElement.getReturnType();
+            typeFactory
+                    .create(returnType, sourceElement)
+                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -16,6 +16,7 @@ import org.example.immutable.processor.generator.ImmutableGeneratorTest;
 import org.example.immutable.processor.modeler.ElementNavigatorTest;
 import org.example.immutable.processor.modeler.ImmutableImplsTest;
 import org.example.immutable.processor.modeler.ImmutableTypesTest;
+import org.example.immutable.processor.modeler.NamedTypesTest;
 import org.example.immutable.processor.modeler.TopLevelTypesTest;
 
 /**
@@ -35,6 +36,7 @@ public interface TestProcessorModule {
     static LiteProcessor provideLiteProcessor(
             Map<Class<? extends LiteProcessor>, LiteProcessor> liteProcessors, Class<? extends LiteProcessor> key) {
         LiteProcessor liteProcessor = liteProcessors.get(key);
+        Objects.requireNonNull(liteProcessor);
         return Objects.requireNonNull(liteProcessor);
     }
 
@@ -84,6 +86,12 @@ public interface TestProcessorModule {
     @IntoMap
     @LiteProcessorClassKey(ImmutableTypesTest.TestLiteProcessor.class)
     LiteProcessor bindImmutableTypesTestLiteProcessor(ImmutableTypesTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(NamedTypesTest.TestLiteProcessor.class)
+    LiteProcessor bindNamedTypesTestLiteProcessor(NamedTypesTest.TestLiteProcessor liteProcessor);
 
     @Binds
     @ProcessorScope

--- a/immutable-processor/src/test/resources/test/method/TypeArray.java
+++ b/immutable-processor/src/test/resources/test/method/TypeArray.java
@@ -1,0 +1,9 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeArray {
+
+    int[][] member();
+}

--- a/immutable-processor/src/test/resources/test/method/TypePrimitive.java
+++ b/immutable-processor/src/test/resources/test/method/TypePrimitive.java
@@ -1,0 +1,9 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypePrimitive {
+
+    int member();
+}

--- a/immutable-processor/src/test/resources/test/method/TypeVariable.java
+++ b/immutable-processor/src/test/resources/test/method/TypeVariable.java
@@ -1,0 +1,9 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeVariable<T> {
+
+    T member();
+}

--- a/immutable-processor/src/test/resources/test/method/error/TypeError.java
+++ b/immutable-processor/src/test/resources/test/method/error/TypeError.java
@@ -1,0 +1,9 @@
+package test.method.error;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeError {
+
+    ImmutableTypeError member();
+}

--- a/immutable-processor/src/test/resources/test/method/error/TypeVoid.java
+++ b/immutable-processor/src/test/resources/test/method/error/TypeVoid.java
@@ -1,0 +1,9 @@
+package test.method.error;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeVoid {
+
+    void member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclared.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclared.java
@@ -1,0 +1,9 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeDeclared {
+
+    String member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredGeneric.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredGeneric.java
@@ -1,0 +1,10 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+import java.util.Map;
+
+@Immutable
+public interface TypeDeclaredGeneric {
+
+    Map<String, String> member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNested.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNested.java
@@ -1,0 +1,9 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeDeclaredNested {
+
+    Thread.UncaughtExceptionHandler member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNestedGenericInstance.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNestedGenericInstance.java
@@ -1,0 +1,14 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeDeclaredNestedGenericInstance {
+
+    Outer<String>.Inner<String> member();
+}
+
+class Outer<O> {
+
+    class Inner<I> {}
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNestedGenericStatic.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredNestedGenericStatic.java
@@ -1,0 +1,10 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+import java.util.Map;
+
+@Immutable
+public interface TypeDeclaredNestedGenericStatic {
+
+    Map.Entry<String, String> member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredPathological.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeDeclaredPathological.java
@@ -1,0 +1,16 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public interface TypeDeclaredPathological {
+
+    OuterDerived<String>.Inner<String> member();
+}
+
+class OuterBase<O> {
+
+    class Inner<I> {}
+}
+
+class OuterDerived<O> extends OuterBase<O> {}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcard.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcard.java
@@ -1,0 +1,10 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+import java.util.List;
+
+@Immutable
+public interface TypeWildcard {
+
+    List<?> member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcardExtends.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcardExtends.java
@@ -1,0 +1,10 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+import java.util.List;
+
+@Immutable
+public interface TypeWildcardExtends {
+
+    List<? extends Runnable> member();
+}

--- a/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcardSuper.java
+++ b/immutable-processor/src/test/resources/test/method/unsupported/TypeWildcardSuper.java
@@ -1,0 +1,10 @@
+package test.method;
+
+import org.example.immutable.Immutable;
+import java.util.List;
+
+@Immutable
+public interface TypeWildcardSuper {
+
+    List<? super Runnable> member();
+}


### PR DESCRIPTION
Overview

- Can translate type names into a `NamedType` for primitive types, array types, and type variables.

main

- Add `NamedTypes`
  - Supports primitive types, array types, type variables.
  - Declared types are not yet supported. 
  - It checks for error cases or unsupported cases.

test

- Add tests for `NamedTypes`: supported cases, unsupported case, error cases.