### PR TITLE
add NamedType.concat() overloads

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/NamedType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/NamedType.java
@@ -35,6 +35,18 @@ public interface NamedType {
         return join(List.of(type1, type2), "", "", "");
     }
 
+    /** Concatenates a type and a suffix into a single type. */
+    static NamedType concat(NamedType type, String suffix) {
+        String nameFormat = String.format("%s%s", type.nameFormat(), suffix);
+        return NamedType.of(nameFormat, type.args());
+    }
+
+    /** Concatenates a prefix and a type into a single type. */
+    static NamedType concat(String prefix, NamedType type) {
+        String nameFormat = String.format("%s%s", prefix, type.nameFormat());
+        return NamedType.of(nameFormat, type.args());
+    }
+
     /** Joins a list of types into a single type. */
     static NamedType join(List<NamedType> types, String delimiter, String prefix, String suffix) {
         String nameFormat =

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
@@ -136,8 +136,7 @@ final class ImmutableTypes {
 
         // Append type variables to the raw type.
         String typeVars = getTypeVars(typeParamElements).stream().collect(Collectors.joining(", ", "<", ">"));
-        String nameFormat = String.format("%s%s", rawInterfaceType.nameFormat(), typeVars);
-        return NamedType.of(nameFormat, rawInterfaceType.args());
+        return NamedType.concat(rawInterfaceType, typeVars);
     }
 
     /** Creates the implementation type from the raw implementation type and the type parameters. */

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/NamedTypeTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/NamedTypeTest.java
@@ -21,12 +21,28 @@ public final class NamedTypeTest {
     }
 
     @Test
-    public void concat() {
+    public void concat_Types() {
         NamedType type1 = NamedType.of("Map");
         NamedType type2 = NamedType.of("<%s, %s>", TopLevelType.of(String.class), TopLevelType.of(Integer.class));
         NamedType type = NamedType.concat(type1, type2);
         assertThat(type.nameFormat()).isEqualTo("Map<%s, %s>");
         assertThat(type.args()).containsExactly(TopLevelType.of(String.class), TopLevelType.of(Integer.class));
+    }
+
+    @Test
+    public void concat_TypeAndSuffix() {
+        NamedType originalType = NamedType.of(TopLevelType.of(String.class));
+        NamedType type = NamedType.concat(originalType, "[]");
+        assertThat(type.nameFormat()).isEqualTo("%s[]");
+        assertThat(type.args()).containsExactly(TopLevelType.of(String.class));
+    }
+
+    @Test
+    public void concat_TypeAndPrefix() {
+        NamedType originalType = NamedType.of(TopLevelType.of(Runnable.class));
+        NamedType type = NamedType.concat("? extends ", originalType);
+        assertThat(type.nameFormat()).isEqualTo("? extends %s");
+        assertThat(type.args()).containsExactly(TopLevelType.of(Runnable.class));
     }
 
     @Test


### PR DESCRIPTION
main

- Add `NamedType.concat()` overloads where the first or second arg is a `String`.
- Refactor processor to use these new overloads.

test

- Update tests for `NamedType`.