### PR TITLE
fit-and-finish

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessor.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessor.java
@@ -17,7 +17,7 @@ public abstract class ImmutableBaseLiteProcessor implements LiteProcessor {
 
     @Override
     public final void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
-        ImmutableBaseLiteProcessor.getImmutableTypes(annotations, roundEnv).forEach(this::process);
+        getImmutableTypes(annotations, roundEnv).forEach(this::process);
     }
 
     /** Processes a type annotated with {@link Immutable}. */

--- a/immutable-processor/src/main/java/org/example/immutable/processor/error/Errors.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/error/Errors.java
@@ -14,6 +14,8 @@ import org.example.immutable.processor.base.ProcessorScope;
  * Reports diagnostic errors, which result in compilation errors.
  *
  * <p>It also tracks errors, which allows processing to continue for non-fatal errors.</p>
+ *
+ * <p>{@link Messager} should not be used directly; this will break the error tracking.</p>
  */
 @ProcessorScope
 public final class Errors {

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
@@ -52,6 +52,15 @@ public final class ImmutableImplsTest {
                 CompilationError.of(8, "[@Immutable] method must not have parameters"));
     }
 
+    @Test
+    public void error_MultipleErrors() {
+        error(
+                "test/error/MultipleErrors.java",
+                CompilationError.of(6, "[@Immutable] type must be an interface"),
+                CompilationError.of(8, "[@Immutable] void type not allowed"),
+                CompilationError.of(10, "[@Immutable] method must not have type parameters"));
+    }
+
     private void error(String sourcePath, CompilationError... expectedErrors) {
         Compilation compilation = TestCompiler.create(TestLiteProcessor.class)
                 .expectingCompilationFailure()

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestCompiler.java
@@ -37,7 +37,11 @@ public final class TestCompiler {
         return new TestCompiler(processor);
     }
 
-    /** Creates a compiler with {@link ImmutableBaseProcessor} and a custom {@link LiteProcessor}. */
+    /**
+     * Creates a compiler with {@link ImmutableBaseProcessor} and a custom {@link LiteProcessor}.
+     *
+     * <p>To be used, the {@link LiteProcessor} class must also be added to {@link TestProcessorModule}.</p>
+     */
     public static TestCompiler create(Class<? extends LiteProcessor> liteProcessorClass) {
         Processor processor = new TestImmutableProcessor(liteProcessorClass);
         return new TestCompiler(processor);

--- a/immutable-processor/src/test/resources/test/error/MultipleErrors.java
+++ b/immutable-processor/src/test/resources/test/error/MultipleErrors.java
@@ -1,0 +1,11 @@
+package test.error;
+
+import org.example.immutable.Immutable;
+
+@Immutable
+public abstract class MultipleErrors {
+
+    public abstract void member1();
+
+    public abstract <T> T member2();
+}


### PR DESCRIPTION
- Small Javadoc updates for `Errors`, `TestCompiler`.
- Remove unnecessary qualifier in `ImmutableBaseLiteProcessor`.
- Add test with multiple errors to `ImmutableImplsTest`.