### PR TITLE
don't look at other types in the package

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
@@ -40,18 +40,15 @@ public interface ImmutableImpl {
     @Value.Derived
     @JsonIgnore
     default TypeQualifier typeQualifier() {
-        // Get the package information for the source.
         String packageName = type().rawImplType().packageName();
-        Set<String> packageTypes = type().packageTypes();
-
-        // Get the type variables and types referenced in the source.
         Set<String> typeVars = Set.copyOf(type().typeVars());
+
         Set<TopLevelType> referencedTypes = new HashSet<>();
         referencedTypes.addAll(Set.of(TopLevelType.ofClass(Generated.class), TopLevelType.ofClass(Override.class)));
         referencedTypes.addAll(type().implType().args());
         referencedTypes.addAll(type().interfaceType().args());
         members().forEach(member -> referencedTypes.addAll(member.type().args()));
 
-        return TypeQualifier.of(packageName, packageTypes, typeVars, referencedTypes);
+        return TypeQualifier.of(packageName, typeVars, referencedTypes);
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableType.java
@@ -3,7 +3,6 @@ package org.example.immutable.processor.model;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
-import java.util.Set;
 import org.immutables.value.Value;
 
 /**
@@ -17,14 +16,9 @@ import org.immutables.value.Value;
 public interface ImmutableType {
 
     static ImmutableType of(
-            TopLevelType rawImplType,
-            Set<String> packageTypes,
-            List<String> typeVars,
-            NamedType implType,
-            NamedType interfaceType) {
+            TopLevelType rawImplType, List<String> typeVars, NamedType implType, NamedType interfaceType) {
         return ImmutableImmutableType.builder()
                 .rawImplType(rawImplType)
-                .packageTypes(packageTypes)
                 .typeVars(typeVars)
                 .implType(implType)
                 .interfaceType(interfaceType)
@@ -33,9 +27,6 @@ public interface ImmutableType {
 
     /** Gets the raw type of the implementing class. */
     TopLevelType rawImplType();
-
-    /** Gets the simple name of all top-level types in the type's package .*/
-    Set<String> packageTypes();
 
     /** Gets the type variables for generic types, or an empty list for non-generic types. */
     List<String> typeVars();

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/TypeQualifier.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/TypeQualifier.java
@@ -17,11 +17,9 @@ import org.immutables.value.Value;
 @JsonDeserialize(as = ImmutableTypeQualifier.class)
 public interface TypeQualifier {
 
-    static TypeQualifier of(
-            String packageName, Set<String> packageTypes, Set<String> typeVars, Set<TopLevelType> referencedTypes) {
+    static TypeQualifier of(String packageName, Set<String> typeVars, Set<TopLevelType> referencedTypes) {
         return ImmutableTypeQualifier.builder()
                 .packageName(packageName)
-                .packageTypes(packageTypes)
                 .typeVars(typeVars)
                 .referencedTypes(referencedTypes)
                 .build();
@@ -29,9 +27,6 @@ public interface TypeQualifier {
 
     /** Gets the package name of the source. */
     String packageName();
-
-    /** Gets the simple name of all top-level types in the source's package. */
-    Set<String> packageTypes();
 
     /** Gets the type variables that are referenced in the source. */
     Set<String> typeVars();
@@ -68,14 +63,6 @@ public interface TypeQualifier {
         Stream<TopLevelType> typeVarConflicts =
                 referencedTypes().stream().filter(type -> typeVars().contains(type.simpleName()));
 
-        // Check that referenced types in the "java.lang" package do not conflict with a type in the source package.
-        // The types in the source's package do not need to be referenced for a conflict to exist.
-        Stream<TopLevelType> javaLangConflicts = referencedTypes().stream()
-                .filter(type -> type.packageName().equals("java.lang"))
-                .filter(type -> packageTypes().contains(type.simpleName()));
-
-        return Stream.of(typeConflicts, typeVarConflicts, javaLangConflicts)
-                .flatMap(s -> s)
-                .collect(Collectors.toSet());
+        return Stream.concat(typeConflicts, typeVarConflicts).collect(Collectors.toSet());
     }
 }

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableImpls.java
@@ -2,7 +2,6 @@ package org.example.immutable.processor.modeler;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import javax.inject.Inject;
 import javax.lang.model.element.TypeElement;
 import org.example.immutable.processor.base.ProcessorScope;
@@ -18,7 +17,7 @@ import org.example.immutable.processor.model.TopLevelType;
 public final class ImmutableImpls {
 
     private static final ImmutableType ERROR_TYPE =
-            ImmutableType.of(TopLevelType.of("?", "?"), Set.of(), List.of(), NamedType.of("?"), NamedType.of("?"));
+            ImmutableType.of(TopLevelType.of("?", "?"), List.of(), NamedType.of("?"), NamedType.of("?"));
     private static final ImmutableMember ERROR_MEMBER = ImmutableMember.of("?", NamedType.of("?"));
 
     private final ImmutableTypes typeFactory;

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/ImmutableTypes.java
@@ -2,14 +2,12 @@ package org.example.immutable.processor.modeler;
 
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
-import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.TypeParameterElement;
 import javax.lang.model.type.TypeMirror;
@@ -53,7 +51,6 @@ final class ImmutableTypes {
             NamedType rawInterfaceType = maybeRawInterfaceType.get();
 
             TopLevelType rawImplType = createRawImplType(rawInterfaceType, typeElement);
-            Set<String> packageTypes = createPackageTypes(typeElement);
 
             // Create and validate the (possibly generic) types.
             List<? extends TypeParameterElement> typeParamElements = typeElement.getTypeParameters();
@@ -62,7 +59,7 @@ final class ImmutableTypes {
             NamedType implType = createImplType(rawImplType, typeParamElements);
 
             // Create the immutable type.
-            ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+            ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
             return errorTracker.checkNoErrors(type);
         }
     }
@@ -111,15 +108,6 @@ final class ImmutableTypes {
         TopLevelType rawImplType = TopLevelType.of(rawFlatInterfaceType.packageName(), simpleImplName);
         checkImplTypeDoesNotExist(rawImplType, sourceElement);
         return rawImplType;
-    }
-
-    /** Creates a list of top-level types in the same package as this type. */
-    private Set<String> createPackageTypes(TypeElement typeElement) {
-        PackageElement packageElement = elementUtils.getPackageOf(typeElement);
-        return packageElement.getEnclosedElements().stream()
-                .map(Element::getSimpleName)
-                .map(Name::toString)
-                .collect(Collectors.toSet());
     }
 
     /** Gets a list of all type variables. */

--- a/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
 import java.util.List;
-import java.util.Set;
 import javax.tools.JavaFileObject;
 import org.example.immutable.processor.model.ImmutableImpl;
 import org.example.immutable.processor.model.ImmutableMember;
@@ -61,13 +60,12 @@ public final class SourceWriterTest {
         // Create the type.
         TopLevelType rawImplType = TopLevelType.of("", "ImmutableInterfaceWithoutPackage");
         TopLevelType rawInterfaceType = TopLevelType.of("", "InterfaceWithoutPackage");
-        Set<String> packageTypes = Set.of("InterfaceWithoutPackage");
 
         List<String> typeVars = List.of();
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the implementation.
         return ImmutableImpl.of(type, List.of());
@@ -77,39 +75,39 @@ public final class SourceWriterTest {
         // Create the type.
         TopLevelType rawImplType = TopLevelType.of("test.source", "ImmutableQualifiedTypes");
         TopLevelType rawInterfaceType = TopLevelType.of("test.source", "QualifiedTypes");
-        Set<String> packageTypes = Set.of("QualifiedTypes", "String", "Generated", "Override");
 
         List<String> typeVars = List.of();
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the members
         TopLevelType stringPackageImport = TopLevelType.of("test.source", "String");
         TopLevelType stringImport = TopLevelType.ofClass(String.class);
         TopLevelType generatedPackageImport = TopLevelType.of("test.source", "Generated");
+        TopLevelType overridePackageImport = TopLevelType.of("test.source", "Override");
 
         ImmutableMember member1 = ImmutableMember.of("member1", NamedType.ofTopLevelType(stringPackageImport));
         ImmutableMember member2 = ImmutableMember.of("member2", NamedType.ofTopLevelType(stringImport));
         ImmutableMember member3 = ImmutableMember.of("member3", NamedType.ofTopLevelType(generatedPackageImport));
+        ImmutableMember member4 = ImmutableMember.of("member4", NamedType.ofTopLevelType(overridePackageImport));
 
         // Create the implementation.
-        return ImmutableImpl.of(type, List.of(member1, member2, member3));
+        return ImmutableImpl.of(type, List.of(member1, member2, member3, member4));
     }
 
     private static ImmutableImpl createImpl_QualifiedTypesDeclaration() {
         // Create the type.
         TopLevelType rawImplType = TopLevelType.of("test.source", "ImmutableQualifiedTypesDeclaration");
         TopLevelType rawInterfaceType = TopLevelType.of("test.source", "QualifiedTypesDeclaration");
-        Set<String> packageTypes = Set.of("QualifiedTypesDeclaration");
 
         List<String> typeVars = List.of("ImmutableQualifiedTypesDeclaration");
         NamedType implType =
                 NamedType.of("%s<ImmutableQualifiedTypesDeclaration extends %s>", rawImplType, rawImplType);
         NamedType interfaceType = NamedType.of("%s<ImmutableQualifiedTypesDeclaration>", rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, packageTypes, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the implementation.
         return ImmutableImpl.of(type, List.of());

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
@@ -25,7 +25,6 @@ public final class ImmutableImplTest {
         TypeQualifier typeQualifier = TestImmutableImpls.coloredRectangle().typeQualifier();
         TypeQualifier expectedTypeQualifier = TypeQualifier.of(
                 "test",
-                Set.of("Rectangle", "ColoredRectangle", "Empty"),
                 Set.of(),
                 Set.of(
                         TopLevelType.ofClass(Generated.class),

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/TypeQualifierTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/TypeQualifierTest.java
@@ -19,7 +19,6 @@ public final class TypeQualifierTest {
         TypeQualifier typeQualifier = TypeQualifier.of(
                 "test",
                 Set.of(),
-                Set.of(),
                 Set.of(
                         TopLevelType.ofClass(Generated.class),
                         TopLevelType.ofClass(List.class),
@@ -36,7 +35,6 @@ public final class TypeQualifierTest {
         TypeQualifier typeQualifier = TypeQualifier.of(
                 "test",
                 Set.of(),
-                Set.of(),
                 Set.of(
                         TopLevelType.ofClass(String.class),
                         TopLevelType.ofClass(List.class),
@@ -47,10 +45,7 @@ public final class TypeQualifierTest {
     @Test
     public void importedTypes_DoNotImportQualifiedTypes() {
         TypeQualifier typeQualifier = TypeQualifier.of(
-                "test",
-                Set.of(),
-                Set.of(),
-                Set.of(TopLevelType.of("test.sub1", "Type"), TopLevelType.of("test.sub2", "Type")));
+                "test", Set.of(), Set.of(TopLevelType.of("test.sub1", "Type"), TopLevelType.of("test.sub2", "Type")));
         assertThat(typeQualifier.importedTypes()).isEmpty();
     }
 
@@ -58,7 +53,6 @@ public final class TypeQualifierTest {
     public void qualifiedTypes_TypeConflictsWithTypeNotInSourcePackage() {
         TypeQualifier typeQualifier = TypeQualifier.of(
                 "test",
-                Set.of(),
                 Set.of(),
                 Set.of(
                         TopLevelType.ofClass(List.class),
@@ -71,29 +65,21 @@ public final class TypeQualifierTest {
     @Test
     public void qualifiedTypes_TypeConflictsWithTypeInSourcePackage() {
         TypeQualifier typeQualifier = TypeQualifier.of(
-                "test", Set.of(), Set.of(), Set.of(TopLevelType.ofClass(List.class), TopLevelType.of("test", "List")));
+                "test", Set.of(), Set.of(TopLevelType.ofClass(List.class), TopLevelType.of("test", "List")));
         assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.ofClass(List.class));
     }
 
     @Test
     public void qualifiedTypes_TypeNotInSourcePackageConflictsWithTypeVariable() {
         TypeQualifier typeQualifier =
-                TypeQualifier.of("test", Set.of(), Set.of("String"), Set.of(TopLevelType.ofClass(String.class)));
+                TypeQualifier.of("test", Set.of("String"), Set.of(TopLevelType.ofClass(String.class)));
         assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.ofClass(String.class));
     }
 
     @Test
     public void qualifiedTypes_TypeInSourcePackageConflictsWithTypeVariable() {
-        TypeQualifier typeQualifier =
-                TypeQualifier.of("test", Set.of(), Set.of("T"), Set.of(TopLevelType.of("Type", "T")));
+        TypeQualifier typeQualifier = TypeQualifier.of("test", Set.of("T"), Set.of(TopLevelType.of("Type", "T")));
         assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.of("Type", "T"));
-    }
-
-    @Test
-    public void qualifiedTypes_JavaLangTypeConflictsWithTypeInSourcePackage() {
-        TypeQualifier typeQualifier =
-                TypeQualifier.of("test", Set.of("Override"), Set.of(), Set.of(TopLevelType.ofClass(Override.class)));
-        assertThat(typeQualifier.qualifiedTypes()).containsExactlyInAnyOrder(TopLevelType.ofClass(Override.class));
     }
 
     @Test

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.google.testing.compile.Compilation;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.Callable;
 import javax.annotation.processing.Filer;
 import javax.inject.Inject;
@@ -36,7 +35,7 @@ public final class ImmutableTypesTest {
         List<String> typeVars = List.of();
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
         create("test/type/Interface.java", expectedType);
     }
 
@@ -47,7 +46,7 @@ public final class ImmutableTypesTest {
         List<String> typeVars = List.of("T", "U");
         NamedType implType = NamedType.of("%s<T, U>", rawImplType);
         NamedType interfaceType = NamedType.of("%s<T, U>", rawInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
         create("test/type/InterfaceGeneric.java", expectedType);
     }
 
@@ -63,7 +62,7 @@ public final class ImmutableTypesTest {
                 TopLevelType.ofClass(Callable.class),
                 TopLevelType.ofClass(Void.class));
         NamedType interfaceType = NamedType.of("%s<T>", rawInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
         create("test/type/InterfaceGenericBounds.java", expectedType);
     }
 
@@ -74,7 +73,7 @@ public final class ImmutableTypesTest {
         List<String> typeVars = List.of();
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.of("%s.Inner", topLevelInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
         create("test/type/InterfaceNested.java", "test/type/InterfaceNested$Inner.json", expectedType);
     }
 
@@ -85,7 +84,7 @@ public final class ImmutableTypesTest {
         List<String> typeVars = List.of();
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, Set.of(), typeVars, implType, interfaceType);
+        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
         create("InterfaceWithoutPackage.java", expectedType);
     }
 
@@ -148,7 +147,7 @@ public final class ImmutableTypesTest {
 
     /** Empties the package types for comparison purposes. */
     private ImmutableType normalizeType(ImmutableType type) {
-        return ImmutableType.of(type.rawImplType(), Set.of(), type.typeVars(), type.implType(), type.interfaceType());
+        return ImmutableType.of(type.rawImplType(), type.typeVars(), type.implType(), type.interfaceType());
     }
 
     @ProcessorScope

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestImmutableImpls.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestImmutableImpls.java
@@ -1,7 +1,6 @@
 package org.example.immutable.processor.test;
 
 import java.util.List;
-import java.util.Set;
 import org.example.immutable.processor.model.ImmutableImpl;
 import org.example.immutable.processor.model.ImmutableMember;
 import org.example.immutable.processor.model.ImmutableType;
@@ -10,8 +9,6 @@ import org.example.immutable.processor.model.TopLevelType;
 
 /** Creates test {@link ImmutableImpl}'s. */
 public final class TestImmutableImpls {
-
-    private static Set<String> PACKAGE_TYPES = Set.of("Rectangle", "ColoredRectangle", "Empty");
 
     private static final ImmutableImpl RECTANGLE = createRectangle();
     private static final ImmutableImpl COLORED_RECTANGLE = createColoredRectangle();
@@ -41,7 +38,7 @@ public final class TestImmutableImpls {
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the members.
         NamedType doubleType = NamedType.of("double");
@@ -62,7 +59,7 @@ public final class TestImmutableImpls {
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the members.
         TopLevelType rectangleImport = TopLevelType.of("test", "Rectangle");
@@ -90,7 +87,7 @@ public final class TestImmutableImpls {
         NamedType implType = NamedType.ofTopLevelType(rawImplType);
         NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
 
-        ImmutableType type = ImmutableType.of(rawImplType, PACKAGE_TYPES, typeVars, implType, interfaceType);
+        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
 
         // Create the implementation.
         return ImmutableImpl.of(type, List.of());

--- a/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypes.java
+++ b/immutable-processor/src/test/resources/generated/test/source/ImmutableQualifiedTypes.java
@@ -6,11 +6,13 @@ class ImmutableQualifiedTypes implements QualifiedTypes {
     private final String member1;
     private final java.lang.String member2;
     private final Generated member3;
+    private final Override member4;
 
-    ImmutableQualifiedTypes(String member1, java.lang.String member2, Generated member3) {
+    ImmutableQualifiedTypes(String member1, java.lang.String member2, Generated member3, Override member4) {
         this.member1 = member1;
         this.member2 = member2;
         this.member3 = member3;
+        this.member4 = member4;
     }
 
     @java.lang.Override
@@ -26,5 +28,10 @@ class ImmutableQualifiedTypes implements QualifiedTypes {
     @java.lang.Override
     public Generated member3() {
         return member3;
+    }
+
+    @java.lang.Override
+    public Override member4() {
+        return member4;
     }
 }

--- a/immutable-processor/src/test/resources/test/source/QualifiedTypes.java
+++ b/immutable-processor/src/test/resources/test/source/QualifiedTypes.java
@@ -10,6 +10,8 @@ public interface QualifiedTypes {
     java.lang.String member2();
 
     Generated member3();
+
+    Override member4();
 }
 
 interface String {}


### PR DESCRIPTION
You probably should not be doing this during incremental annotation processing anyway.

This would result in a compilation error for one particular edge case, but this edge case involves a violation of ErrorProne's [`JavaLangClash`](http://errorprone.info/bugpattern/JavaLangClash) bug pattern.

None of the possible options for this edge case (ignore it, handle it, throw an error) work cleanly with an incremental compilation. The root problem is this: if a new source is added that violates `JavaLangClash`, it would not trigger an incremental recompilation of other sources in the package, even though it may affect the compilation of those sources.

Thus, we'll ignore it.

- It avoids looking at other types in the package.
- It's the simplest option.
- As before, no option works cleanly with an incremental compilation.

We could revisit this decision later, based on https://github.com/gradle/gradle/issues/24718