### PR TITLE
set up debugging on the forking compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,11 @@ class ImmutableRectangle implements Rectangle {
 
 - `./gradlew -Dorg.gradle.debug=true --no-daemon :immutable-example:clean :immutable-example:compileJava`
   - From there, you can attach a debugger to Gradle.
-  - You will likely need to comment out the three ErrorProne lines in
-    [`org.example.immutable.java-conventions.gradle`](buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle).
+  - If you use a [forking compiler](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.compile.CompileOptions.html#org.gradle.api.tasks.compile.CompileOptions:fork),
+    however, you will need to [set up debugging](buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle)
+    on the forked process.
+    - This project uses the Error Prone plugin, which uses a forking compiler,
+      so the `org.gradle.debugfork` option was added to enable debugging on the forked process.
 - You could also debug a test written with [Compile Testing](https://github.com/google/compile-testing).
 
 ### Where can the generated sources be found?

--- a/buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle
@@ -9,7 +9,6 @@ repositories {
 }
 
 dependencies {
-    // You may need to disable ErrorProne if you want to run './gradlew -Dorg.gradle.debug=true --no-daemon ...'.
     errorprone('com.google.errorprone:error_prone_core')
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api'
@@ -28,6 +27,13 @@ tasks.withType(JavaCompile) {
     options.release = 17
     options.compilerArgs << '-Werror'
     options.errorprone.disableWarningsInGeneratedCode = true
+
+    // The Error Prone plugin uses a forking compiler for JDK 16+.
+    // The 'org.gradle.debugfork' option has been added to enable debugging on the forked process.
+    if (System.properties.getProperty('org.gradle.debugfork', 'false').toBoolean()) {
+        // Use port 5006 on the off chance that the original process is listening for a debugger on port 5005.
+        options.forkOptions.jvmArgs << '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006'
+    }
 }
 
 tasks.named('test') {


### PR DESCRIPTION
- This project uses the Error Prone plugin, which uses a forking compiler on JDK 16+.
- The `org.gradle.debugfork` property was added to enable debugging on the forked process.

One possible alternative was to reuse the `org.gradle.debug` property.

- However, by default, that option still makes the original process suspend until a debugger is attached.
- Thus, you would have to attach a debugger twice: once for the original process, and once for the forked process.
- There does not appear to be a way to disable debugging on the original process if this property is set.