### PR TITLE
avoid forking compiler for Error Prone

### DIFF
--- a/buildSrc/build.gradle
+++ b/buildSrc/build.gradle
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     implementation 'com.diffplug.spotless:spotless-plugin-gradle:6.12.0'
-    implementation 'net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:3.0.1'
+    implementation 'net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin:3.1.0'
 }

--- a/buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/org.example.immutable.java-conventions.gradle
@@ -23,17 +23,15 @@ spotless {
     }
 }
 
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
+}
+
 tasks.withType(JavaCompile) {
-    options.release = 17
     options.compilerArgs << '-Werror'
     options.errorprone.disableWarningsInGeneratedCode = true
-
-    // The Error Prone plugin uses a forking compiler for JDK 16+.
-    // The 'org.gradle.debugfork' option has been added to enable debugging on the forked process.
-    if (System.properties.getProperty('org.gradle.debugfork', 'false').toBoolean()) {
-        // Use port 5006 on the off chance that the original process is listening for a debugger on port 5005.
-        options.forkOptions.jvmArgs << '-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5006'
-    }
 }
 
 tasks.named('test') {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,13 @@
+# With JDK 16+, these JVM args are needed so that the Error Prone plugin won't use a forking compiler.
+org.gradle.jvmargs=\
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED \
+  --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED


### PR DESCRIPTION
(Also use `java` `toolchain` instead of `options.release`)

See: https://github.com/tbroyer/gradle-errorprone-plugin/issues/76