### PR TITLE
add MemberType

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/MemberType.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/MemberType.java
@@ -1,0 +1,173 @@
+package org.example.immutable.processor.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.example.processor.source.SourceGenerator;
+import org.example.processor.type.ImportableType;
+import org.immutables.value.Value;
+
+/**
+ * Type for an immutable member (or for the declaration of the immutable type itself).
+ *
+ * <p>Its name is represented as a format string, with {@link ImportableType}'s as the arguments.</p>
+ */
+@Value.Immutable
+@JsonSerialize(as = ImmutableMemberType.class)
+@JsonDeserialize(as = ImmutableMemberType.class)
+public interface MemberType {
+
+    /** Creates a {@link MemberType} from a format string for the name and the {@link ImportableType} arguments. */
+    static MemberType of(String nameFormat, List<ImportableType> args) {
+        return ImmutableMemberType.builder().nameFormat(nameFormat).args(args).build();
+    }
+
+    /** Creates a {@link MemberType} from a format string for the name and the {@link ImportableType} arguments. */
+    static MemberType of(String nameFormat, ImportableType... args) {
+        return of(nameFormat, List.of(args));
+    }
+
+    /** Creates a {@link MemberType} for a primitive type. */
+    static MemberType primitiveType(String primitive) {
+        return of(primitive);
+    }
+
+    /** Creates a {@link MemberType} for an array type. */
+    static MemberType arrayType(MemberType componentType) {
+        String nameFormat = String.format("%s[]", componentType.nameFormat());
+        return of(nameFormat, componentType.args());
+    }
+
+    /** Creates a {@link MemberType} for a declared type, possibly a generic type with type arguments. */
+    static MemberType declaredType(ImportableType rawType, List<MemberType> typeArgs) {
+        if (typeArgs.isEmpty()) {
+            return of("%s", rawType);
+        }
+
+        String nameFormat = typeArgs.stream().map(MemberType::nameFormat).collect(Collectors.joining(", ", "%s<", ">"));
+        List<ImportableType> args = new ArrayList<>(List.of(rawType));
+        typeArgs.stream().map(MemberType::args).forEach(args::addAll);
+        return of(nameFormat, args);
+    }
+
+    /** Creates a {@link MemberType} for a declared type, possibly a generic type with type arguments. */
+    static MemberType declaredType(ImportableType rawType, MemberType... typeArgs) {
+        return declaredType(rawType, List.of(typeArgs));
+    }
+
+    /** Creates a {@link MemberType} for a type parameter, which may be bounded to extend one or more types. */
+    static MemberType typeParameter(String name, List<MemberType> bounds) {
+        if (bounds.isEmpty()) {
+            return of(name);
+        }
+
+        String prefix = String.format("%s extends ", name);
+        String nameFormat = bounds.stream().map(MemberType::nameFormat).collect(Collectors.joining(" & ", prefix, ""));
+        List<ImportableType> args =
+                bounds.stream().map(MemberType::args).flatMap(List::stream).toList();
+        return of(nameFormat, args);
+    }
+
+    /** Creates a {@link MemberType} for a type parameter, which may be bounded to extend one or more types. */
+    static MemberType typeParameter(String name, MemberType... bounds) {
+        return typeParameter(name, List.of(bounds));
+    }
+
+    /** Creates a {@link MemberType} for a type variable. */
+    static MemberType typeVariable(String name) {
+        return of(name);
+    }
+
+    /** Creates a {@link MemberType} for a wildcard type. */
+    static MemberType wildcardType() {
+        return of("?");
+    }
+
+    /** Creates a {@link MemberType} for a wildcard type that is bounded to extend a type. */
+    static MemberType wildcardExtendsType(MemberType bound) {
+        String nameFormat = String.format("? extends %s", bound.nameFormat());
+        return of(nameFormat, bound.args());
+    }
+
+    /** Creates a {@link MemberType} for a wildcard type that is bounded to be a super type. */
+    static MemberType wildcardSuperType(MemberType bound) {
+        String nameFormat = String.format("? super %s", bound.nameFormat());
+        return of(nameFormat, bound.args());
+    }
+
+    /** Gets the format string for the name. */
+    String nameFormat();
+
+    /** Gets the {@link ImportableType} arguments. */
+    List<ImportableType> args();
+
+    /** Gets the raw type for a declared type. */
+    @Value.Lazy
+    @JsonIgnore
+    default ImportableType rawType() {
+        return args().get(0);
+    }
+
+    /**
+     * Adds type arguments to an outer type that is generic.
+     *
+     * <p>If multiple outer types are generic, type arguments should be added to the innermost type first.</p>
+     */
+    default MemberType addTypeArgumentsToOuterType(ImportableType rawOuterType, List<MemberType> outerTypeArgs) {
+        String qualifiedSuffix = rawType().qualifiedSuffix(rawOuterType);
+        String suffix = String.format(">%s%s", qualifiedSuffix, nameFormat().substring(2));
+        String nameFormat =
+                outerTypeArgs.stream().map(MemberType::nameFormat).collect(Collectors.joining(", ", "%s<", suffix));
+
+        List<ImportableType> args = new ArrayList<>(List.of(rawOuterType));
+        outerTypeArgs.stream().map(MemberType::args).forEach(args::addAll);
+        args.addAll(args().subList(1, args().size()));
+        return of(nameFormat, args);
+    }
+
+    /**
+     * Adds type arguments to an outer type that is generic.
+     *
+     * <p>If multiple outer types are generic, type arguments should be added to the innermost type first.</p>
+     */
+    default MemberType addTypeArgumentsToOuterType(ImportableType rawOuterType, MemberType... outerTypeArgs) {
+        return addTypeArgumentsToOuterType(rawOuterType, List.of(outerTypeArgs));
+    }
+
+    /** Gets a {@link MemberType} for a declared top-level type that can be used for the type's declaration. */
+    @Value.Lazy
+    @JsonIgnore
+    default MemberType topLevelDeclaration() {
+        String nameFormat =
+                String.format("%s%s", rawType().simpleName(), nameFormat().substring(2));
+        List<ImportableType> args = args().subList(1, args().size());
+        return of(nameFormat, args);
+    }
+
+    /** Generates the source for a {@link MemberType}. */
+    class Namer implements SourceGenerator<MemberType> {
+
+        private final SourceGenerator<ImportableType> importableTypeNamer;
+
+        /** Creates a namer for {@link MemberType}'s from a namer for {@link ImportableType}'s. */
+        public static Namer of(SourceGenerator<ImportableType> importableTypeNamer) {
+            return new Namer(importableTypeNamer);
+        }
+
+        @Override
+        public void generateSource(PrintWriter writer, MemberType type) {
+            Object[] args =
+                    type.args().stream().map(importableTypeNamer::toSource).toArray();
+            String name = String.format(type.nameFormat(), args);
+            writer.print(name);
+        }
+
+        private Namer(SourceGenerator<ImportableType> importableTypeNamer) {
+            this.importableTypeNamer = importableTypeNamer;
+        }
+    }
+}

--- a/immutable-processor/src/main/java/org/example/immutable/processor/modeler/MemberTypes.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/modeler/MemberTypes.java
@@ -1,0 +1,185 @@
+package org.example.immutable.processor.modeler;
+
+import java.util.List;
+import java.util.Optional;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.ArrayType;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ErrorType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.IntersectionType;
+import javax.lang.model.type.NoType;
+import javax.lang.model.type.NullType;
+import javax.lang.model.type.PrimitiveType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.type.TypeVariable;
+import javax.lang.model.type.TypeVisitor;
+import javax.lang.model.type.UnionType;
+import javax.lang.model.type.WildcardType;
+import javax.lang.model.util.Elements;
+import org.example.immutable.processor.error.Errors;
+import org.example.immutable.processor.model.MemberType;
+import org.example.processor.type.ImportableType;
+
+/**
+ * Creates {@link MemberType}'s from {@link TypeMirror}'s.
+ *
+ * <p>The source {@link Element} is also provided for error reporting purposes.</p>
+ */
+final class MemberTypes {
+
+    public static final MemberType ERROR_TYPE = MemberType.of("!");
+
+    private final Errors errorReporter;
+    private final Elements elementUtils;
+
+    @Inject
+    MemberTypes(Errors errorReporter, Elements elementUtils) {
+        this.errorReporter = errorReporter;
+        this.elementUtils = elementUtils;
+    }
+
+    /** Creates a {@link MemberType} from a {@link TypeMirror}, or empty if validation fails. */
+    public Optional<MemberType> create(TypeMirror typeMirror, Element sourceElement) {
+        try (Errors.Tracker errorTracker = errorReporter.createErrorTracker()) {
+            MemberType typeModel = new Builder(sourceElement).build(typeMirror);
+            return errorTracker.checkNoErrors(typeModel);
+        }
+    }
+
+    /** Recursively builds the {@link MemberType} from the {@link TypeMirror}. */
+    private class Builder implements TypeVisitor<MemberType, Void> {
+
+        private final Element sourceElement;
+
+        public Builder(Element sourceElement) {
+            this.sourceElement = sourceElement;
+        }
+
+        public MemberType build(TypeMirror typeMirror) {
+            return typeMirror.accept(this, null);
+        }
+
+        @Override
+        public MemberType visitPrimitive(PrimitiveType primitiveType, Void unused) {
+            return MemberType.primitiveType(primitiveType.toString());
+        }
+
+        @Override
+        public MemberType visitArray(ArrayType arrayType, Void unused) {
+            MemberType componentTypeModel = build(arrayType.getComponentType());
+            return MemberType.arrayType(componentTypeModel);
+        }
+
+        @Override
+        public MemberType visitDeclared(DeclaredType declaredType, Void unused) {
+            ImportableType rawType = toImportableType(declaredType);
+            List<MemberType> typeArgModels = visitTypeArguments(declaredType);
+            MemberType typeModel = MemberType.declaredType(rawType, typeArgModels);
+            return addTypeArgumentsToOuterTypes(declaredType, typeModel);
+        }
+
+        @Override
+        public MemberType visitTypeVariable(TypeVariable typeVariable, Void unused) {
+            return MemberType.typeVariable(typeVariable.toString());
+        }
+
+        @Override
+        public MemberType visitWildcard(WildcardType wildcardType, Void unused) {
+            Optional<TypeMirror> maybeExtendsBound = Optional.ofNullable(wildcardType.getExtendsBound());
+            if (maybeExtendsBound.isPresent()) {
+                TypeMirror bound = maybeExtendsBound.get();
+                MemberType boundModel = build(bound);
+                return MemberType.wildcardExtendsType(boundModel);
+            }
+
+            Optional<TypeMirror> maybeSuperBound = Optional.ofNullable(wildcardType.getSuperBound());
+            if (maybeSuperBound.isPresent()) {
+                TypeMirror bound = maybeSuperBound.get();
+                MemberType boundModel = build(bound);
+                return MemberType.wildcardSuperType(boundModel);
+            }
+
+            return MemberType.wildcardType();
+        }
+
+        @Override
+        public MemberType visitNoType(NoType noType, Void unused) {
+            return error("void type not allowed");
+        }
+
+        @Override
+        public MemberType visitError(ErrorType errorType, Void unused) {
+            return error("type failed to compile");
+        }
+
+        @Override
+        public MemberType visit(TypeMirror typeMirror, Void unused) {
+            return error("unexpected: type");
+        }
+
+        @Override
+        public MemberType visitNull(NullType nullType, Void unused) {
+            return error("unexpected: null type");
+        }
+
+        @Override
+        public MemberType visitExecutable(ExecutableType executableType, Void unused) {
+            return error("unexpected: executable type");
+        }
+
+        @Override
+        public MemberType visitUnion(UnionType unionType, Void unused) {
+            // Union types are only used in catch statements.
+            return error("unexpected: union type");
+        }
+
+        @Override
+        public MemberType visitIntersection(IntersectionType intersectionType, Void unused) {
+            // Intersection types are only used in casts.
+            return error("unexpected: intersection type");
+        }
+
+        @Override
+        public MemberType visitUnknown(TypeMirror typeMirror, Void unused) {
+            return error("unexpected: unknown type");
+        }
+
+        /** Converts a {@link DeclaredType} to an {@link ImportableType}. */
+        private ImportableType toImportableType(DeclaredType declaredType) {
+            TypeElement typeElement = (TypeElement) declaredType.asElement();
+            String binaryName = elementUtils.getBinaryName(typeElement).toString();
+            return ImportableType.of(binaryName);
+        }
+
+        /** Visits the type arguments for a {@link DeclaredType}. */
+        private List<MemberType> visitTypeArguments(DeclaredType declaredType) {
+            return declaredType.getTypeArguments().stream().map(this::build).toList();
+        }
+
+        /** Adds type arguments to outer types that are generic. */
+        private MemberType addTypeArgumentsToOuterTypes(DeclaredType declaredType, MemberType typeModel) {
+            DeclaredType outerDeclaredType = declaredType;
+            while (outerDeclaredType.getEnclosingType().getKind() != TypeKind.NONE) {
+                outerDeclaredType = (DeclaredType) outerDeclaredType.getEnclosingType();
+                if (outerDeclaredType.getTypeArguments().isEmpty()) {
+                    continue;
+                }
+
+                ImportableType rawOuterType = toImportableType(outerDeclaredType);
+                List<MemberType> outerTypeArgModels = visitTypeArguments(outerDeclaredType);
+                typeModel = typeModel.addTypeArgumentsToOuterType(rawOuterType, outerTypeArgModels);
+            }
+            return typeModel;
+        }
+
+        /** Reports an error and returns an error type. */
+        private MemberType error(String message) {
+            errorReporter.error(message, sourceElement);
+            return ERROR_TYPE;
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/MemberTypeTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/MemberTypeTest.java
@@ -1,0 +1,152 @@
+package org.example.immutable.processor.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.PrintWriter;
+import java.util.Map;
+import org.example.immutable.processor.test.TestResources;
+import org.example.processor.type.ImportableType;
+import org.junit.jupiter.api.Test;
+
+public final class MemberTypeTest {
+
+    @Test
+    public void primitiveType() {
+        MemberType type = MemberType.primitiveType("int");
+        assertThat(type.nameFormat()).isEqualTo("int");
+        assertThat(type.args()).isEmpty();
+    }
+
+    @Test
+    public void arrayType() {
+        MemberType type = MemberType.arrayType(MemberType.primitiveType("int"));
+        assertThat(type.nameFormat()).isEqualTo("int[]");
+        assertThat(type.args()).isEmpty();
+    }
+
+    @Test
+    public void declaredType_NonGeneric() {
+        MemberType type = MemberType.declaredType(ImportableType.ofClass(String.class));
+        assertThat(type.nameFormat()).isEqualTo("%s");
+        assertThat(type.args()).containsExactly(ImportableType.ofClass(String.class));
+        assertThat(type.rawType()).isEqualTo(ImportableType.ofClass(String.class));
+    }
+
+    @Test
+    public void declaredType_Generic() {
+        MemberType type = MemberType.declaredType(
+                ImportableType.ofClass(Map.class),
+                MemberType.declaredType(ImportableType.ofClass(String.class)),
+                MemberType.declaredType(ImportableType.ofClass(Integer.class)));
+        assertThat(type.nameFormat()).isEqualTo("%s<%s, %s>");
+        assertThat(type.args())
+                .containsExactly(
+                        ImportableType.ofClass(Map.class),
+                        ImportableType.ofClass(String.class),
+                        ImportableType.ofClass(Integer.class));
+        assertThat(type.rawType()).isEqualTo(ImportableType.ofClass(Map.class));
+    }
+
+    @Test
+    public void declaredType_AddTypeArgumentsToOuterTypes() {
+        ImportableType rawInner2Type = ImportableType.of("test.Outer$Inner$Inner2");
+        ImportableType rawInnerType = ImportableType.of("test.Outer$Inner");
+        ImportableType rawOuterType = ImportableType.of("test.Outer");
+        MemberType typeArg = MemberType.declaredType(ImportableType.ofClass(Integer.class));
+
+        MemberType type = MemberType.declaredType(rawInner2Type, typeArg);
+        type = type.addTypeArgumentsToOuterType(rawInnerType, typeArg);
+        type = type.addTypeArgumentsToOuterType(rawOuterType, typeArg);
+        assertThat(type.nameFormat()).isEqualTo("%s<%s>.Inner<%s>.Inner2<%s>");
+        assertThat(type.args())
+                .containsExactly(
+                        rawOuterType,
+                        ImportableType.ofClass(Integer.class),
+                        ImportableType.ofClass(Integer.class),
+                        ImportableType.ofClass(Integer.class));
+    }
+
+    @Test
+    public void typeParameter_NoBounds() {
+        MemberType type = MemberType.typeParameter("T");
+        assertThat(type.nameFormat()).isEqualTo("T");
+        assertThat(type.args()).isEmpty();
+    }
+
+    @Test
+    public void typeParameter_Bounds() {
+        MemberType type = MemberType.typeParameter(
+                "T",
+                MemberType.declaredType(ImportableType.ofClass(Runnable.class)),
+                MemberType.declaredType(ImportableType.ofClass(Comparable.class), MemberType.typeVariable("T")));
+        assertThat(type.nameFormat()).isEqualTo("T extends %s & %s<T>");
+        assertThat(type.args())
+                .containsExactly(ImportableType.ofClass(Runnable.class), ImportableType.ofClass(Comparable.class));
+    }
+
+    @Test
+    public void typeVariable() {
+        MemberType type = MemberType.typeVariable("T");
+        assertThat(type.nameFormat()).isEqualTo("T");
+        assertThat(type.args()).isEmpty();
+    }
+
+    @Test
+    public void wildcardType() {
+        MemberType type = MemberType.wildcardType();
+        assertThat(type.nameFormat()).isEqualTo("?");
+        assertThat(type.args()).isEmpty();
+    }
+
+    @Test
+    public void wildcardExtendsType() {
+        MemberType type =
+                MemberType.wildcardExtendsType(MemberType.declaredType(ImportableType.ofClass(Runnable.class)));
+        assertThat(type.nameFormat()).isEqualTo("? extends %s");
+        assertThat(type.args()).containsExactly(ImportableType.ofClass(Runnable.class));
+    }
+
+    @Test
+    public void wildcardSuperType() {
+        MemberType type = MemberType.wildcardSuperType(MemberType.declaredType(ImportableType.ofClass(Runnable.class)));
+        assertThat(type.nameFormat()).isEqualTo("? super %s");
+        assertThat(type.args()).containsExactly(ImportableType.ofClass(Runnable.class));
+    }
+
+    @Test
+    public void topLevelDeclaration() {
+        MemberType type = MemberType.declaredType(
+                ImportableType.ofClass(Map.class),
+                MemberType.declaredType(ImportableType.ofClass(String.class)),
+                MemberType.declaredType(ImportableType.ofClass(Integer.class)));
+        MemberType declarationType = type.topLevelDeclaration();
+        assertThat(declarationType.nameFormat()).isEqualTo("Map<%s, %s>");
+        assertThat(declarationType.args())
+                .containsExactly(ImportableType.ofClass(String.class), ImportableType.ofClass(Integer.class));
+    }
+
+    @Test
+    public void serializeAndDeserialize() throws JsonProcessingException {
+        MemberType type = MemberType.declaredType(ImportableType.ofClass(String.class));
+        TestResources.serializeAndDeserialize(type, new TypeReference<>() {});
+    }
+
+    @Test
+    public void toSource() {
+        MemberType.Namer typeNamer = MemberType.Namer.of(MemberTypeTest::generateSourceForImportableType);
+        MemberType type = MemberType.declaredType(
+                ImportableType.ofClass(Map.class),
+                MemberType.declaredType(ImportableType.ofClass(String.class)),
+                MemberType.declaredType(ImportableType.ofClass(Integer.class)));
+        assertThat(typeNamer.toSource(type)).isEqualTo("Map<java.lang.String, Integer>");
+    }
+
+    private static void generateSourceForImportableType(PrintWriter writer, ImportableType importableType) {
+        String name = !importableType.equals(ImportableType.ofClass(String.class))
+                ? importableType.simpleName()
+                : importableType.qualifiedName();
+        writer.print(name);
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
@@ -1,0 +1,145 @@
+package org.example.immutable.processor.modeler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.google.testing.compile.Compilation;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.processing.Filer;
+import javax.inject.Inject;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
+import org.example.immutable.processor.base.ProcessorScope;
+import org.example.immutable.processor.model.MemberType;
+import org.example.immutable.processor.test.CompilationError;
+import org.example.immutable.processor.test.TestCompiler;
+import org.example.immutable.processor.test.TestResources;
+import org.example.processor.type.ImportableType;
+import org.junit.jupiter.api.Test;
+
+public final class MemberTypesTest {
+
+    @Test
+    public void create_TypeArray() throws Exception {
+        MemberType expectedType = MemberType.of("int[][]");
+        create("test/method/TypeArray.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeDeclared() throws Exception {
+        MemberType expectedType = MemberType.of("%s", ImportableType.ofClass(String.class));
+        create("test/method/TypeDeclared.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeDeclaredGeneric() throws Exception {
+        MemberType expectedType = MemberType.of(
+                "%s<%s, %s>",
+                ImportableType.ofClass(Map.class),
+                ImportableType.ofClass(String.class),
+                ImportableType.ofClass(String.class));
+        create("test/method/TypeDeclaredGeneric.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeDeclaredNestedGenericInstance() throws Exception {
+        MemberType expectedType = MemberType.of(
+                "%s<%s>.Inner<%s>",
+                ImportableType.of("test.method.Outer"),
+                ImportableType.ofClass(String.class),
+                ImportableType.ofClass(String.class));
+        create("test/method/TypeDeclaredNestedGenericInstance.java", expectedType);
+    }
+
+    @Test
+    public void create_TypePrimitive() throws Exception {
+        MemberType expectedType = MemberType.of("int");
+        create("test/method/TypePrimitive.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeVariable() throws Exception {
+        MemberType expectedType = MemberType.of("T");
+        create("test/method/TypeVariable.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeWildcard() throws Exception {
+        MemberType expectedType = MemberType.of("%s<?>", ImportableType.ofClass(List.class));
+        create("test/method/TypeWildcard.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeWildcardExtends() throws Exception {
+        MemberType expectedType = MemberType.of(
+                "%s<? extends %s>", ImportableType.ofClass(List.class), ImportableType.ofClass(Runnable.class));
+        create("test/method/TypeWildcardExtends.java", expectedType);
+    }
+
+    @Test
+    public void create_TypeWildcardSuper() throws Exception {
+        MemberType expectedType = MemberType.of(
+                "%s<? super %s>", ImportableType.ofClass(List.class), ImportableType.ofClass(Runnable.class));
+        create("test/method/TypeWildcardSuper.java", expectedType);
+    }
+
+    private void create(String sourcePath, MemberType expectedType) throws Exception {
+        Compilation compilation =
+                TestCompiler.create(MemberTypesTest.TestLiteProcessor.class).compile(sourcePath);
+        MemberType type = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});
+        assertThat(type).isEqualTo(expectedType);
+    }
+
+    @Test
+    public void error_TypeVoid() {
+        error("test/method/error/TypeVoid.java", CompilationError.of(8, "[@Immutable] void type not allowed"));
+    }
+
+    @Test
+    public void error_TypeError() {
+        Compilation compilation = TestCompiler.create(MemberTypesTest.TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .expectingCompilationFailureWithoutProcessor()
+                .compile("test/method/error/TypeError.java");
+        assertThat(CompilationError.fromCompilation(compilation))
+                .contains(CompilationError.of(8, "[@Immutable] type failed to compile"));
+    }
+
+    private void error(String sourcePath, CompilationError expectedError) {
+        Compilation compilation = TestCompiler.create(MemberTypesTest.TestLiteProcessor.class)
+                .expectingCompilationFailure()
+                .compile(sourcePath);
+        assertThat(CompilationError.fromCompilation(compilation)).containsExactlyInAnyOrder(expectedError);
+    }
+
+    @ProcessorScope
+    public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
+
+        private final MemberTypes typeFactory;
+        private final ElementNavigator navigator;
+        private final Elements elementUtils;
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(MemberTypes types, ElementNavigator navigator, Elements elementUtils, Filer filer) {
+            this.typeFactory = types;
+            this.navigator = navigator;
+            this.elementUtils = elementUtils;
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(TypeElement typeElement) {
+            ExecutableElement sourceElement =
+                    navigator.getMethodsToImplement(typeElement).findFirst().get();
+            TypeMirror returnType = sourceElement.getReturnType();
+            typeFactory
+                    .create(returnType, sourceElement)
+                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, elementUtils, type));
+        }
+    }
+}

--- a/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/test/TestProcessorModule.java
@@ -17,6 +17,7 @@ import org.example.immutable.processor.modeler.ElementNavigatorTest;
 import org.example.immutable.processor.modeler.ImmutableImplsTest;
 import org.example.immutable.processor.modeler.ImmutableMembersTest;
 import org.example.immutable.processor.modeler.ImmutableTypesTest;
+import org.example.immutable.processor.modeler.MemberTypesTest;
 import org.example.immutable.processor.modeler.NamedTypesTest;
 
 /**
@@ -92,6 +93,12 @@ public interface TestProcessorModule {
     @IntoMap
     @LiteProcessorClassKey(ImmutableTypesTest.TestLiteProcessor.class)
     LiteProcessor bindImmutableTypesTestLiteProcessor(ImmutableTypesTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(MemberTypesTest.TestLiteProcessor.class)
+    LiteProcessor bindMemberTypesTestLiteProcessor(MemberTypesTest.TestLiteProcessor liteProcessor);
 
     @Binds
     @ProcessorScope


### PR DESCRIPTION
`MemberType` is designed to be a simplified replacement for `NamedType`, built on top of `ImportableType`.