### PR TITLE
simplify TestResources

### DIFF
--- a/immutable-processor/src/test/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/base/ImmutableBaseLiteProcessorTest.java
@@ -7,7 +7,6 @@ import com.google.testing.compile.Compilation;
 import javax.annotation.processing.Filer;
 import javax.inject.Inject;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.test.TestCompiler;
 import org.example.immutable.processor.test.TestResources;
 import org.junit.jupiter.api.Test;
@@ -28,19 +27,17 @@ public final class ImmutableBaseLiteProcessorTest {
     @ProcessorScope
     public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
 
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(Elements elementUtils, Filer filer) {
-            this.elementUtils = elementUtils;
+        TestLiteProcessor(Filer filer) {
             this.filer = filer;
         }
 
         @Override
         protected void process(TypeElement typeElement) {
             String qualifiedName = typeElement.getQualifiedName().toString();
-            TestResources.saveObject(filer, typeElement, elementUtils, qualifiedName);
+            TestResources.saveObject(filer, typeElement, qualifiedName);
         }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ElementNavigatorTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ElementNavigatorTest.java
@@ -10,7 +10,6 @@ import javax.inject.Inject;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.test.TestCompiler;
@@ -34,13 +33,11 @@ public final class ElementNavigatorTest {
     public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
 
         private final ElementNavigator navigator;
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(ElementNavigator navigator, Elements elementUtils, Filer filer) {
+        TestLiteProcessor(ElementNavigator navigator, Filer filer) {
             this.navigator = navigator;
-            this.elementUtils = elementUtils;
             this.filer = filer;
         }
 
@@ -51,7 +48,7 @@ public final class ElementNavigatorTest {
                     .map(Element::getSimpleName)
                     .map(Name::toString)
                     .toList();
-            TestResources.saveObject(filer, typeElement, elementUtils, methodNames);
+            TestResources.saveObject(filer, typeElement, methodNames);
         }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableImplsTest.java
@@ -7,7 +7,6 @@ import com.google.testing.compile.Compilation;
 import javax.annotation.processing.Filer;
 import javax.inject.Inject;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.ImmutableImpl;
@@ -72,21 +71,17 @@ public final class ImmutableImplsTest {
     public static final class TestLiteProcessor extends ImmutableBaseLiteProcessor {
 
         private final ImmutableImpls implFactory;
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(ImmutableImpls implFactory, Elements elementUtils, Filer filer) {
+        TestLiteProcessor(ImmutableImpls implFactory, Filer filer) {
             this.implFactory = implFactory;
-            this.elementUtils = elementUtils;
             this.filer = filer;
         }
 
         @Override
         protected void process(TypeElement typeElement) {
-            implFactory
-                    .create(typeElement)
-                    .ifPresent(impl -> TestResources.saveObject(filer, typeElement, elementUtils, impl));
+            implFactory.create(typeElement).ifPresent(impl -> TestResources.saveObject(filer, typeElement, impl));
         }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableMembersTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableMembersTest.java
@@ -64,7 +64,6 @@ public final class ImmutableMembersTest {
 
         private final ImmutableMembers memberFactory;
         private final ElementNavigator navigator;
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
@@ -72,7 +71,6 @@ public final class ImmutableMembersTest {
                 ImmutableMembers memberFactory, ElementNavigator navigator, Elements elementUtils, Filer filer) {
             this.memberFactory = memberFactory;
             this.navigator = navigator;
-            this.elementUtils = elementUtils;
             this.filer = filer;
         }
 
@@ -82,7 +80,7 @@ public final class ImmutableMembersTest {
                     navigator.getMethodsToImplement(typeElement).findFirst().get();
             memberFactory
                     .create(methodElement)
-                    .ifPresent(member -> TestResources.saveObject(filer, typeElement, elementUtils, member));
+                    .ifPresent(member -> TestResources.saveObject(filer, typeElement, member));
         }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
@@ -121,14 +121,12 @@ public final class MemberTypesTest {
 
         private final MemberTypes typeFactory;
         private final ElementNavigator navigator;
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
         TestLiteProcessor(MemberTypes types, ElementNavigator navigator, Elements elementUtils, Filer filer) {
             this.typeFactory = types;
             this.navigator = navigator;
-            this.elementUtils = elementUtils;
             this.filer = filer;
         }
 
@@ -139,7 +137,7 @@ public final class MemberTypesTest {
             TypeMirror returnType = sourceElement.getReturnType();
             typeFactory
                     .create(returnType, sourceElement)
-                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, elementUtils, type));
+                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
         }
     }
 }

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/NamedTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/NamedTypesTest.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.NamedType;
@@ -146,14 +145,12 @@ public final class NamedTypesTest {
 
         private final NamedTypes typeFactory;
         private final ElementNavigator navigator;
-        private final Elements elementUtils;
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(NamedTypes types, ElementNavigator navigator, Elements elementUtils, Filer filer) {
+        TestLiteProcessor(NamedTypes types, ElementNavigator navigator, Filer filer) {
             this.typeFactory = types;
             this.navigator = navigator;
-            this.elementUtils = elementUtils;
             this.filer = filer;
         }
 
@@ -164,7 +161,7 @@ public final class NamedTypesTest {
             TypeMirror returnType = sourceElement.getReturnType();
             typeFactory
                     .create(returnType, sourceElement)
-                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, elementUtils, type));
+                    .ifPresent(type -> TestResources.saveObject(filer, typeElement, type));
         }
     }
 }


### PR DESCRIPTION
* For nested types, the resource file is associated with the source/top-level type.
* `TestResources.saveObject()` no longer requires an `Elements` arg.