### PR TITLE
generate package and imports in processor project

### DIFF
--- a/immutable-processor/src/main/java/org/example/immutable/processor/generator/SourceWriter.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/generator/SourceWriter.java
@@ -2,7 +2,6 @@ package org.example.immutable.processor.generator;
 
 import java.io.PrintWriter;
 import java.io.Writer;
-import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.processing.Generated;
 import org.example.immutable.processor.ImmutableProcessor;
@@ -11,7 +10,7 @@ import org.example.immutable.processor.model.ImmutableMember;
 import org.example.immutable.processor.model.ImmutableType;
 import org.example.immutable.processor.model.NamedType;
 import org.example.immutable.processor.model.TopLevelType;
-import org.example.processor.type.ImportableType;
+import org.example.processor.imports.ImportGenerator;
 
 /** Writes the source code for an {@link ImmutableImpl}, using an open {@link Writer}. */
 final class SourceWriter {
@@ -38,7 +37,7 @@ final class SourceWriter {
 
     /** Writes the source code. */
     private void writeSource() {
-        writePackageAndImports();
+        ImportGenerator.instance().generateSource(writer, impl.importManager());
         writeClassHeader();
         if (impl.members().isEmpty()) {
             writeConstructor();
@@ -49,23 +48,6 @@ final class SourceWriter {
         writeConstructor();
         writeMethods();
         writeClassFooter();
-    }
-
-    /** Writes the package and the imports. */
-    private void writePackageAndImports() {
-        String packageName = impl.type().rawImplType().packageName();
-        List<ImportableType> importDeclarations = impl.importManager().getImportDeclarations();
-
-        if (!packageName.isEmpty()) {
-            writer.format("package %s;", packageName).println();
-            writer.println();
-        }
-
-        if (!importDeclarations.isEmpty()) {
-            importDeclarations.forEach(
-                    type -> writer.format("import %s;", type.qualifiedName()).println());
-            writer.println();
-        }
     }
 
     /** Writes the class declaration and the opening curly brace. */

--- a/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
+++ b/immutable-processor/src/main/java/org/example/immutable/processor/model/ImmutableImpl.java
@@ -57,7 +57,7 @@ public interface ImmutableImpl {
         // Create the import manager.
         String packageName = type().rawImplType().packageName();
         Set<String> inScopeNames = Set.copyOf(type().typeVars());
-        return TopLevelImportManager.of(referencedTypes, packageName, inScopeNames);
+        return TopLevelImportManager.of(packageName, referencedTypes, inScopeNames);
     }
 
     private static void addAllTopLevelTypes(

--- a/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/generator/SourceWriterTest.java
@@ -35,11 +35,6 @@ public final class SourceWriterTest {
     }
 
     @Test
-    public void writeSource_InterfaceWithoutPackage() throws IOException {
-        writeSource(createImpl_InterfaceWithoutPackage(), "generated/ImmutableInterfaceWithoutPackage.java");
-    }
-
-    @Test
     public void writeSource_QualifiedTypes() throws IOException {
         writeSource(createImpl_QualifiedTypes(), "generated/test/source/ImmutableQualifiedTypes.java");
     }
@@ -54,21 +49,6 @@ public final class SourceWriterTest {
     private void writeSource(ImmutableImpl impl, String expectedSourcePath) throws IOException {
         String source = writeSourceToString(impl);
         assertThat(source).isEqualTo(loadSource(expectedSourcePath));
-    }
-
-    private static ImmutableImpl createImpl_InterfaceWithoutPackage() {
-        // Create the type.
-        TopLevelType rawImplType = TopLevelType.of("", "ImmutableInterfaceWithoutPackage");
-        TopLevelType rawInterfaceType = TopLevelType.of("", "InterfaceWithoutPackage");
-
-        List<String> typeVars = List.of();
-        NamedType implType = NamedType.ofTopLevelType(rawImplType);
-        NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
-
-        ImmutableType type = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
-
-        // Create the implementation.
-        return ImmutableImpl.of(type, List.of());
     }
 
     private static ImmutableImpl createImpl_QualifiedTypes() {

--- a/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/model/ImmutableImplTest.java
@@ -29,6 +29,7 @@ public final class ImmutableImplTest {
         String packageName =
                 TestImmutableImpls.coloredRectangle().type().rawImplType().packageName();
         ImportManager expectedImportManager = SimpleImportManager.of(
+                packageName,
                 Set.of(
                         ImportableType.ofClass(Generated.class),
                         ImportableType.ofClass(Override.class),
@@ -36,8 +37,7 @@ public final class ImmutableImplTest {
                         ImportableType.of("test.ColoredRectangle"),
                         ImportableType.of("test.Rectangle"),
                         ImportableType.ofClass(Color.class),
-                        ImportableType.ofClass(Optional.class)),
-                packageName);
+                        ImportableType.ofClass(Optional.class)));
         assertThat(importManager).isEqualTo(expectedImportManager);
     }
 

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableMembersTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableMembersTest.java
@@ -8,7 +8,6 @@ import javax.annotation.processing.Filer;
 import javax.inject.Inject;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.ImmutableMember;
@@ -67,8 +66,7 @@ public final class ImmutableMembersTest {
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(
-                ImmutableMembers memberFactory, ElementNavigator navigator, Elements elementUtils, Filer filer) {
+        TestLiteProcessor(ImmutableMembers memberFactory, ElementNavigator navigator, Filer filer) {
             this.memberFactory = memberFactory;
             this.navigator = navigator;
             this.filer = filer;

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/ImmutableTypesTest.java
@@ -76,17 +76,6 @@ public final class ImmutableTypesTest {
         create("test/type/InterfaceNested.java", expectedType);
     }
 
-    @Test
-    public void create_InterfaceWithoutPackage() throws Exception {
-        TopLevelType rawImplType = TopLevelType.of("", "ImmutableInterfaceWithoutPackage");
-        TopLevelType rawInterfaceType = TopLevelType.of("", "InterfaceWithoutPackage");
-        List<String> typeVars = List.of();
-        NamedType implType = NamedType.ofTopLevelType(rawImplType);
-        NamedType interfaceType = NamedType.ofTopLevelType(rawInterfaceType);
-        ImmutableType expectedType = ImmutableType.of(rawImplType, typeVars, implType, interfaceType);
-        create("InterfaceWithoutPackage.java", expectedType);
-    }
-
     private void create(String sourcePath, ImmutableType expectedType) throws Exception {
         Compilation compilation = TestCompiler.create(TestLiteProcessor.class).compile(sourcePath);
         ImmutableType type = TestResources.loadObjectForSource(compilation, sourcePath, new TypeReference<>() {});

--- a/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
+++ b/immutable-processor/src/test/java/org/example/immutable/processor/modeler/MemberTypesTest.java
@@ -11,7 +11,6 @@ import javax.inject.Inject;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.Elements;
 import org.example.immutable.processor.base.ImmutableBaseLiteProcessor;
 import org.example.immutable.processor.base.ProcessorScope;
 import org.example.immutable.processor.model.MemberType;
@@ -124,7 +123,7 @@ public final class MemberTypesTest {
         private final Filer filer;
 
         @Inject
-        TestLiteProcessor(MemberTypes types, ElementNavigator navigator, Elements elementUtils, Filer filer) {
+        TestLiteProcessor(MemberTypes types, ElementNavigator navigator, Filer filer) {
             this.typeFactory = types;
             this.navigator = navigator;
             this.filer = filer;

--- a/immutable-processor/src/test/resources/InterfaceWithoutPackage.java
+++ b/immutable-processor/src/test/resources/InterfaceWithoutPackage.java
@@ -1,4 +1,0 @@
-import org.example.immutable.Immutable;
-
-@Immutable
-public interface InterfaceWithoutPackage {}

--- a/immutable-processor/src/test/resources/generated/ImmutableInterfaceWithoutPackage.java
+++ b/immutable-processor/src/test/resources/generated/ImmutableInterfaceWithoutPackage.java
@@ -1,8 +1,0 @@
-import javax.annotation.processing.Generated;
-
-@Generated("org.example.immutable.processor.ImmutableProcessor")
-class ImmutableInterfaceWithoutPackage implements InterfaceWithoutPackage {
-
-    ImmutableInterfaceWithoutPackage() {
-    }
-}

--- a/processor/src/main/java/org/example/processor/imports/BaseImportManager.java
+++ b/processor/src/main/java/org/example/processor/imports/BaseImportManager.java
@@ -23,24 +23,31 @@ public abstract class BaseImportManager implements ImportManager {
             return false;
         }
 
-        return getImportDeclarations().equals(other.getImportDeclarations())
-                && getImplicitlyImportedTypes().equals(other.getImplicitlyImportedTypes());
+        return packageName().equals(other.packageName())
+                && importDeclarations().equals(other.importDeclarations())
+                && implicitlyImportedTypes().equals(other.implicitlyImportedTypes());
     }
 
     @Override
     public final int hashCode() {
-        return Objects.hash(getImportDeclarations(), getImplicitlyImportedTypes());
+        return Objects.hash(packageName(), importDeclarations(), implicitlyImportedTypes());
     }
 
     @Override
     public final String toString() {
-        Set<ImportableType> sortedImplicitlyImportedTypes = new TreeSet<>(getImplicitlyImportedTypes());
+        Set<ImportableType> sortedImplicitlyImportedTypes = new TreeSet<>(implicitlyImportedTypes());
         String fieldsString = List.of(
-                        fieldToString("importDeclarations", getImportDeclarations()),
+                        fieldToString("packageName", packageName()),
+                        fieldToString("importDeclarations", importDeclarations()),
                         fieldToString("implicitlyImportedTypes", sortedImplicitlyImportedTypes))
                 .stream()
                 .collect(Collectors.joining(", "));
         return String.format("ImportManager{%s}", fieldsString);
+    }
+
+    /** Converts a field to a string. */
+    private String fieldToString(String name, String value) {
+        return String.format("%s=%s", name, value);
     }
 
     /** Converts a field to a string. */

--- a/processor/src/main/java/org/example/processor/imports/ImportGenerator.java
+++ b/processor/src/main/java/org/example/processor/imports/ImportGenerator.java
@@ -1,0 +1,50 @@
+package org.example.processor.imports;
+
+import java.io.PrintWriter;
+import java.util.List;
+import org.example.processor.source.SourceGenerator;
+import org.example.processor.type.ImportableType;
+
+/**
+ * Generates the package declaration and import declarations from an {@link ImportManager}.
+ *
+ * <p>It assumes that there are no static imports.</p>
+ */
+public final class ImportGenerator implements SourceGenerator<ImportManager> {
+
+    private static final SourceGenerator<ImportManager> INSTANCE = new ImportGenerator();
+
+    /** Gets the singleton instance of {@link ImportGenerator}. */
+    public static SourceGenerator<ImportManager> instance() {
+        return INSTANCE;
+    }
+
+    @Override
+    public void generateSource(PrintWriter writer, ImportManager importManager) {
+        generatePackageDeclaration(writer, importManager.packageName());
+        generateImportDeclarations(writer, importManager.importDeclarations());
+    }
+
+    private ImportGenerator() {}
+
+    /** Generates a package declaration, unless the unnamed package is used. */
+    private void generatePackageDeclaration(PrintWriter writer, String packageName) {
+        if (packageName.isEmpty()) {
+            return;
+        }
+
+        writer.format("package %s;", packageName).println();
+        writer.println();
+    }
+
+    /** Generates the import declarations. */
+    private void generateImportDeclarations(PrintWriter writer, List<ImportableType> importDeclarations) {
+        if (importDeclarations.isEmpty()) {
+            return;
+        }
+
+        importDeclarations.forEach(
+                type -> writer.format("import %s;", type.qualifiedName()).println());
+        writer.println();
+    }
+}

--- a/processor/src/main/java/org/example/processor/imports/ImportManager.java
+++ b/processor/src/main/java/org/example/processor/imports/ImportManager.java
@@ -16,8 +16,11 @@ import org.example.processor.type.ImportableType;
  */
 public interface ImportManager extends SourceGenerator<ImportableType> {
 
+    /** Gets the package name for the generated source code. */
+    String packageName();
+
     /** Gets the import declarations in sorted order. */
-    List<ImportableType> getImportDeclarations();
+    List<ImportableType> importDeclarations();
 
     /**
      * Gets the implicitly imported types.
@@ -27,5 +30,5 @@ public interface ImportManager extends SourceGenerator<ImportableType> {
      *
      * <p>Implicitly imported types that are not referenced may or may not be included.</p>
      */
-    Set<ImportableType> getImplicitlyImportedTypes();
+    Set<ImportableType> implicitlyImportedTypes();
 }

--- a/processor/src/main/java/org/example/processor/imports/SimpleImportManager.java
+++ b/processor/src/main/java/org/example/processor/imports/SimpleImportManager.java
@@ -23,31 +23,36 @@ public final class SimpleImportManager extends BaseImportManager {
 
     private static final Splitter NAME_SPLITTER = Splitter.on('.');
 
+    private final String packageName;
     private final ImportTrie trie;
     private final List<ImportableType> importDeclarations;
     private final Set<ImportableType> implicitlyImportedTypes;
 
     /**
-     * Creates an {@link ImportManager} from a set of imported types and the package name.
+     * Creates an {@link ImportManager} from a package name and a set of imported types.
      *
      * <p>If an implicitly imported type must be referenced using its fully qualified name
      * (e.g., the simple name conflicts with another name in scope), it must not be included.</p>
      *
-     * @param importedTypes set of types imported in the generated source code, including implicitly imported types
      * @param packageName package name for the generated source code
+     * @param importedTypes set of types imported in the generated source code, including implicitly imported types
      */
-    public static ImportManager of(Set<ImportableType> importedTypes, String packageName) {
-        Set<String> implicitlyImportedPackages = Set.of("java.lang", packageName);
-        return new SimpleImportManager(importedTypes, implicitlyImportedPackages);
+    public static ImportManager of(String packageName, Set<ImportableType> importedTypes) {
+        return new SimpleImportManager(packageName, importedTypes);
     }
 
     @Override
-    public List<ImportableType> getImportDeclarations() {
+    public String packageName() {
+        return packageName;
+    }
+
+    @Override
+    public List<ImportableType> importDeclarations() {
         return importDeclarations;
     }
 
     @Override
-    public Set<ImportableType> getImplicitlyImportedTypes() {
+    public Set<ImportableType> implicitlyImportedTypes() {
         return implicitlyImportedTypes;
     }
 
@@ -60,8 +65,10 @@ public final class SimpleImportManager extends BaseImportManager {
         writer.print(shortenedName);
     }
 
-    /** Creates an import manager from the imported types and the implicitly imported packages. */
-    private SimpleImportManager(Set<ImportableType> importedTypes, Set<String> implicitlyImportedPackages) {
+    /** Creates an import manager from the package name and the imported types. */
+    private SimpleImportManager(String packageName, Set<ImportableType> importedTypes) {
+        Set<String> implicitlyImportedPackages = Set.of("java.lang", packageName);
+        this.packageName = packageName;
         trie = ImportTrie.createRoot();
         populateTrie(importedTypes, implicitlyImportedPackages);
         importDeclarations = collectImportDeclarations();

--- a/processor/src/main/java/org/example/processor/imports/TopLevelImportManager.java
+++ b/processor/src/main/java/org/example/processor/imports/TopLevelImportManager.java
@@ -16,13 +16,13 @@ public final class TopLevelImportManager {
      * has the same simple name as a referenced type in the {@code java.lang} package.
      * To handle this edge case, add all top-level types in the package to the set of referenced types.</p>
      *
-     * @param referencedTypes set of types referenced in the generated source code
      * @param packageName package name for the generated source code
+     * @param referencedTypes set of types referenced in the generated source code
      * @param inScopeNames set of other names that could be in scope (e.g., type variables)
      */
-    public static ImportManager of(Set<ImportableType> referencedTypes, String packageName, Set<String> inScopeNames) {
+    public static ImportManager of(String packageName, Set<ImportableType> referencedTypes, Set<String> inScopeNames) {
         Set<ImportableType> importedTypes = getImportedTypes(referencedTypes, packageName, inScopeNames);
-        return SimpleImportManager.of(importedTypes, packageName);
+        return SimpleImportManager.of(packageName, importedTypes);
     }
 
     /** Gets the set of imported types, including implicitly imported types. */

--- a/processor/src/test/java/org/example/processor/imports/BaseImportManagerTest.java
+++ b/processor/src/test/java/org/example/processor/imports/BaseImportManagerTest.java
@@ -24,43 +24,55 @@ public final class BaseImportManagerTest {
         ImportManager importManager = createImportManager();
         assertThat(importManager.toString())
                 .isEqualTo(
-                        "ImportManager{importDeclarations=[java.util.List, java.util.Map$Entry], implicitlyImportedTypes=[java.lang.Object, java.lang.String]}");
+                        "ImportManager{packageName=org.example, importDeclarations=[java.util.List, java.util.Map$Entry], implicitlyImportedTypes=[java.lang.Object, java.lang.String]}");
     }
 
     private static ImportManager createImportManager() {
         return DirectImportManager.of(
+                "org.example",
                 List.of(ImportableType.ofClass(List.class), ImportableType.ofClass(Map.Entry.class)),
                 Set.of(ImportableType.ofClass(Object.class), ImportableType.ofClass(String.class)));
     }
 
-    /** Directly provides the imported types. */
+    /** Directly provides the package name and the imported types. */
     private static final class DirectImportManager extends BaseImportManager {
 
+        private final String packageName;
         private final List<ImportableType> importDeclarations;
         private final Set<ImportableType> implicitlyImportedTypes;
 
         public static ImportManager of(
-                List<ImportableType> importDeclarations, Set<ImportableType> implicitlyImportedTypes) {
-            return new DirectImportManager(importDeclarations, implicitlyImportedTypes);
+                String packageName,
+                List<ImportableType> importDeclarations,
+                Set<ImportableType> implicitlyImportedTypes) {
+            return new DirectImportManager(packageName, importDeclarations, implicitlyImportedTypes);
         }
 
         @Override
-        public List<ImportableType> getImportDeclarations() {
+        public String packageName() {
+            return packageName;
+        }
+
+        @Override
+        public List<ImportableType> importDeclarations() {
             return importDeclarations;
         }
 
         @Override
-        public Set<ImportableType> getImplicitlyImportedTypes() {
+        public Set<ImportableType> implicitlyImportedTypes() {
             return implicitlyImportedTypes;
         }
 
         @Override
-        public void generateSource(PrintWriter writer, ImportableType entity) {
+        public void generateSource(PrintWriter writer, ImportableType type) {
             throw new UnsupportedOperationException();
         }
 
         private DirectImportManager(
-                List<ImportableType> importDeclarations, Set<ImportableType> implicitlyImportedTypes) {
+                String packageName,
+                List<ImportableType> importDeclarations,
+                Set<ImportableType> implicitlyImportedTypes) {
+            this.packageName = packageName;
             this.importDeclarations = importDeclarations;
             this.implicitlyImportedTypes = implicitlyImportedTypes;
         }

--- a/processor/src/test/java/org/example/processor/imports/ImportGeneratorTest.java
+++ b/processor/src/test/java/org/example/processor/imports/ImportGeneratorTest.java
@@ -1,0 +1,56 @@
+package org.example.processor.imports;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.PrintWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.example.processor.type.ImportableType;
+import org.junit.jupiter.api.Test;
+
+public final class ImportGeneratorTest {
+
+    @Test
+    public void toSource() {
+        ImportManager importManager = DirectImportManager.of(
+                "org.example", List.of(ImportableType.ofClass(List.class), ImportableType.ofClass(Map.class)));
+        String expectedSource = String.join(
+                "\n", "package org.example;", "", "import java.util.List;", "import java.util.Map;", "", "");
+        assertThat(ImportGenerator.instance().toSource(importManager)).isEqualTo(expectedSource);
+    }
+
+    @Test
+    public void toSource_UnnamedPackage() {
+        ImportManager importManager = DirectImportManager.of("", List.of(ImportableType.ofClass(List.class)));
+        String expectedSource = String.join("\n", "import java.util.List;", "", "");
+        assertThat(ImportGenerator.instance().toSource(importManager)).isEqualTo(expectedSource);
+    }
+
+    @Test
+    public void toSource_NoImportDeclarations() {
+        ImportManager importManager = DirectImportManager.of("org.example", List.of());
+        String expectedSource = String.join("\n", "package org.example;", "", "");
+        assertThat(ImportGenerator.instance().toSource(importManager)).isEqualTo(expectedSource);
+    }
+
+    /** Directly provides the package name and import declarations. */
+    @SuppressWarnings("UnusedVariable") // false positive for Error Prone
+    private record DirectImportManager(String packageName, List<ImportableType> importDeclarations)
+            implements ImportManager {
+
+        public static ImportManager of(String packageName, List<ImportableType> importDeclarations) {
+            return new DirectImportManager(packageName, importDeclarations);
+        }
+
+        @Override
+        public Set<ImportableType> implicitlyImportedTypes() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void generateSource(PrintWriter writer, ImportableType type) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/processor/src/test/java/org/example/processor/imports/SimpleImportManagerTest.java
+++ b/processor/src/test/java/org/example/processor/imports/SimpleImportManagerTest.java
@@ -14,63 +14,68 @@ import org.junit.jupiter.api.Test;
 public final class SimpleImportManagerTest {
 
     @Test
+    public void getPackageName() {
+        ImportManager importManager = SimpleImportManager.of("org.example", Set.of());
+        assertThat(importManager.packageName()).isEqualTo("org.example");
+    }
+
+    @Test
     public void getImportDeclarations_SortedOrder() {
         ImportManager importManager = SimpleImportManager.of(
+                "org.example",
                 Set.of(
                         ImportableType.ofClass(Generated.class),
                         ImportableType.ofClass(Map.class),
-                        ImportableType.ofClass(List.class)),
-                "org.example");
-        assertThat(importManager.getImportDeclarations())
+                        ImportableType.ofClass(List.class)));
+        assertThat(importManager.importDeclarations())
                 .containsExactly(
                         ImportableType.ofClass(List.class),
                         ImportableType.ofClass(Map.class),
                         ImportableType.ofClass(Generated.class));
-        assertThat(importManager.getImplicitlyImportedTypes()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes()).isEmpty();
     }
 
     @Test
     public void getImportDeclarations_ExcludeJavaLangPackage() {
         ImportManager importManager =
-                SimpleImportManager.of(Set.of(ImportableType.ofClass(String.class)), "org.example");
-        assertThat(importManager.getImportDeclarations()).isEmpty();
-        assertThat(importManager.getImplicitlyImportedTypes())
+                SimpleImportManager.of("org.example", Set.of(ImportableType.ofClass(String.class)));
+        assertThat(importManager.importDeclarations()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes())
                 .containsExactlyInAnyOrder(ImportableType.ofClass(String.class));
     }
 
     @Test
     public void getImportDeclarations_ExcludeCurrentPackage() {
         ImportManager importManager =
-                SimpleImportManager.of(Set.of(ImportableType.of("org.example.Example")), "org.example");
-        assertThat(importManager.getImportDeclarations()).isEmpty();
-        assertThat(importManager.getImplicitlyImportedTypes())
+                SimpleImportManager.of("org.example", Set.of(ImportableType.of("org.example.Example")));
+        assertThat(importManager.importDeclarations()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes())
                 .containsExactlyInAnyOrder(ImportableType.of("org.example.Example"));
     }
 
     @Test
     public void getImportDeclarations_IncludeCurrentSubPackage() {
         ImportManager importManager =
-                SimpleImportManager.of(Set.of(ImportableType.of("org.example.sub.SubExample")), "org.example");
-        assertThat(importManager.getImportDeclarations())
-                .containsExactly(ImportableType.of("org.example.sub.SubExample"));
-        assertThat(importManager.getImplicitlyImportedTypes()).isEmpty();
+                SimpleImportManager.of("org.example", Set.of(ImportableType.of("org.example.sub.SubExample")));
+        assertThat(importManager.importDeclarations()).containsExactly(ImportableType.of("org.example.sub.SubExample"));
+        assertThat(importManager.implicitlyImportedTypes()).isEmpty();
     }
 
     @Test
     public void toSource_Imported() {
-        ImportManager importManager = SimpleImportManager.of(Set.of(ImportableType.ofClass(Map.class)), "org.example");
+        ImportManager importManager = SimpleImportManager.of("org.example", Set.of(ImportableType.ofClass(Map.class)));
         assertThat(importManager.toSource(ImportableType.ofClass(Map.class))).isEqualTo("Map");
     }
 
     @Test
     public void toSource_NotImported() {
-        ImportManager importManager = SimpleImportManager.of(Set.of(), "org.example");
+        ImportManager importManager = SimpleImportManager.of("org.example", Set.of());
         assertThat(importManager.toSource(ImportableType.ofClass(Map.class))).isEqualTo("java.util.Map");
     }
 
     @Test
     public void toSource_PartiallyImported() {
-        ImportManager importManager = SimpleImportManager.of(Set.of(ImportableType.ofClass(Map.class)), "org.example");
+        ImportManager importManager = SimpleImportManager.of("org.example", Set.of(ImportableType.ofClass(Map.class)));
         assertThat(importManager.toSource(ImportableType.ofClass(Map.Entry.class)))
                 .isEqualTo("Map.Entry");
     }
@@ -78,7 +83,7 @@ public final class SimpleImportManagerTest {
     @Test
     public void toSource_ShortestName() {
         ImportManager importManager = SimpleImportManager.of(
-                Set.of(ImportableType.ofClass(Map.class), ImportableType.ofClass(Map.Entry.class)), "org.example");
+                "org.example", Set.of(ImportableType.ofClass(Map.class), ImportableType.ofClass(Map.Entry.class)));
         assertThat(importManager.toSource(ImportableType.ofClass(Map.Entry.class)))
                 .isEqualTo("Entry");
     }
@@ -88,8 +93,8 @@ public final class SimpleImportManagerTest {
         String expectedMessage = String.join(
                 "\n", "conflicting imports found:", "Map: {", "    java.util.Map,", "    org.example.Map,", "}");
         assertThatThrownBy(() -> SimpleImportManager.of(
-                        ImmutableSet.of(ImportableType.ofClass(Map.class), ImportableType.of("org.example.Map")),
-                        "org.example"))
+                        "org.example",
+                        ImmutableSet.of(ImportableType.ofClass(Map.class), ImportableType.of("org.example.Map"))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage(expectedMessage);
     }

--- a/processor/src/test/java/org/example/processor/imports/TopLevelImportManagerTest.java
+++ b/processor/src/test/java/org/example/processor/imports/TopLevelImportManagerTest.java
@@ -12,11 +12,11 @@ public final class TopLevelImportManagerTest {
     @Test
     public void of() {
         ImportManager importManager = TopLevelImportManager.of(
-                Set.of(ImportableType.of("org.example.Example"), ImportableType.ofClass(Map.Entry.class)),
                 "org.example",
+                Set.of(ImportableType.of("org.example.Example"), ImportableType.ofClass(Map.Entry.class)),
                 Set.of());
-        assertThat(importManager.getImportDeclarations()).containsExactly(ImportableType.ofClass(Map.class));
-        assertThat(importManager.getImplicitlyImportedTypes())
+        assertThat(importManager.importDeclarations()).containsExactly(ImportableType.ofClass(Map.class));
+        assertThat(importManager.implicitlyImportedTypes())
                 .containsExactlyInAnyOrder(ImportableType.of("org.example.Example"));
         assertThat(importManager.toSource(ImportableType.ofClass(Map.Entry.class)))
                 .isEqualTo("Map.Entry");
@@ -27,29 +27,29 @@ public final class TopLevelImportManagerTest {
     @Test
     public void of_DoNotImportNonPackageTypeConflictingWithType() {
         ImportManager importManager = TopLevelImportManager.of(
-                Set.of(ImportableType.of("test.Map$Nested"), ImportableType.ofClass(Map.Entry.class)),
                 "org.example",
+                Set.of(ImportableType.of("test.Map$Nested"), ImportableType.ofClass(Map.Entry.class)),
                 Set.of());
-        assertThat(importManager.getImportDeclarations()).isEmpty();
-        assertThat(importManager.getImplicitlyImportedTypes()).isEmpty();
+        assertThat(importManager.importDeclarations()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes()).isEmpty();
     }
 
     @Test
     public void of_ImportPackageTypeConflictingWithType() {
         ImportManager importManager = TopLevelImportManager.of(
-                Set.of(ImportableType.of("org.example.Map"), ImportableType.ofClass(Map.class)),
                 "org.example",
+                Set.of(ImportableType.of("org.example.Map"), ImportableType.ofClass(Map.class)),
                 Set.of());
-        assertThat(importManager.getImportDeclarations()).isEmpty();
-        assertThat(importManager.getImplicitlyImportedTypes())
+        assertThat(importManager.importDeclarations()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes())
                 .containsExactlyInAnyOrder(ImportableType.of("org.example.Map"));
     }
 
     @Test
     public void of_DoNotImportTypeConflictingWithInScopeName() {
         ImportManager importManager =
-                TopLevelImportManager.of(Set.of(ImportableType.ofClass(Map.class)), "org.example", Set.of("Map"));
-        assertThat(importManager.getImportDeclarations()).isEmpty();
-        assertThat(importManager.getImplicitlyImportedTypes()).isEmpty();
+                TopLevelImportManager.of("org.example", Set.of(ImportableType.ofClass(Map.class)), Set.of("Map"));
+        assertThat(importManager.importDeclarations()).isEmpty();
+        assertThat(importManager.implicitlyImportedTypes()).isEmpty();
     }
 }

--- a/versions.props
+++ b/versions.props
@@ -1,7 +1,7 @@
 com.fasterxml.jackson.*:* = 2.14.1
 com.google.auto.service:* = 1.0.1
 com.google.dagger:* = 2.44.2
-com.google.errorprone:error_prone_core = 2.16
+com.google.errorprone:error_prone_core = 2.18.0
 com.google.guava:* = 31.1-jre
 com.google.testing.compile:compile-testing = 0.19
 javax.inject:javax.inject = 1


### PR DESCRIPTION
- Add `ImportGenerator` to `processor` project, which generates package and import declarations
- Changes to `ImportManager`
  - Add getter for package name, put package name first in arg list of implementations
  - Don't use `get` prefix for getters
- Use `ImportGenerator` in `SourceWriter`
  - Delete E2E tests for package-less sources. 
- Upgrade Error Prone version
  - Need to fix some newly idenfied issues 