### PR TITLE
add generic Processor infra to processor

### DIFF
--- a/processor/build.gradle
+++ b/processor/build.gradle
@@ -5,10 +5,16 @@ plugins {
 
 dependencies {
     compileOnly 'org.immutables:value-annotations'
+    annotationProcessor 'com.google.dagger:dagger-compiler'
     annotationProcessor 'org.immutables:value'
 
     implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'com.google.dagger:dagger'
     implementation 'com.google.guava:guava'
+    implementation 'javax.inject:javax.inject'
+
+    testAnnotationProcessor 'com.google.dagger:dagger-compiler'
 
     testImplementation 'com.google.guava:guava-testlib'
+    testImplementation 'com.google.testing.compile:compile-testing'
 }

--- a/processor/src/main/java/org/example/processor/base/AdapterProcessor.java
+++ b/processor/src/main/java/org/example/processor/base/AdapterProcessor.java
@@ -1,0 +1,60 @@
+package org.example.processor.base;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.Set;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+
+/**
+ * {@link Processor} that is an adapter for a {@link LiteProcessor}.
+ *
+ * <p>The {@link LiteProcessor} is created via the abstract method
+ * {@link #createLiteProcessor(ProcessingEnvironment)}.</p>
+ *
+ * <p>It also handles uncaught exceptions in the {@link LiteProcessor}.</p>
+ */
+public abstract class AdapterProcessor implements Processor {
+
+    private LiteProcessor liteProcessor;
+    private Messager messager;
+
+    @Override
+    public final void init(ProcessingEnvironment processingEnv) {
+        liteProcessor = createLiteProcessor(processingEnv);
+        messager = processingEnv.getMessager();
+    }
+
+    /** Creates a {@link LiteProcessor} from the {@link ProcessingEnvironment}. */
+    protected abstract LiteProcessor createLiteProcessor(ProcessingEnvironment processingEnv);
+
+    @Override
+    public final boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+        if (annotations.isEmpty()) {
+            return false;
+        }
+
+        try {
+            liteProcessor.process(annotations, roundEnv);
+        } catch (Exception e) {
+            String message = createUncaughtExceptionMessage(e);
+            messager.printMessage(Diagnostic.Kind.ERROR, message);
+        }
+        return false;
+    }
+
+    /** Create the error message for an uncaught exception. */
+    private String createUncaughtExceptionMessage(Exception e) {
+        StringWriter messageWriter = new StringWriter();
+        PrintWriter writer = new PrintWriter(messageWriter);
+        String processorName = getClass().getCanonicalName();
+        writer.format("Uncaught exception processing annotations in %s:", processorName)
+                .println();
+        e.printStackTrace(writer);
+        return messageWriter.toString();
+    }
+}

--- a/processor/src/main/java/org/example/processor/base/IsolatingLiteProcessor.java
+++ b/processor/src/main/java/org/example/processor/base/IsolatingLiteProcessor.java
@@ -1,0 +1,59 @@
+package org.example.processor.base;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Target;
+import java.util.Optional;
+import java.util.Set;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Isolating {@link LiteProcessor} where each output is generated from a single input.
+ *
+ * <p>It contains a single abstract method, {@link #process(Element)}, which processes a single annotated element.</p>
+ *
+ * <p>It is assumed that the type parameter {@code E} corresponds to the the {@link Target} for the annotation.
+ * E.g., if {@code E} is a {@link TypeElement}, the annotation is annotated with {@code @Target(ElementType.TYPE)}.</p>
+ */
+public abstract class IsolatingLiteProcessor<E extends Element> implements LiteProcessor {
+
+    private final String targetAnnotationCanonicalName;
+
+    /** Creates an {@link IsolatingLiteProcessor} for the provided annotation. */
+    protected IsolatingLiteProcessor(Class<? extends Annotation> targetAnnotation) {
+        targetAnnotationCanonicalName = targetAnnotation.getCanonicalName();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public final void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws Exception {
+        Optional<TypeElement> maybeAnnotationToProcess = findAnnotationToProcess(annotations);
+        if (maybeAnnotationToProcess.isEmpty()) {
+            return;
+        }
+        TypeElement annotationToProcess = maybeAnnotationToProcess.get();
+
+        Set<? extends Element> annotatedElements = roundEnv.getElementsAnnotatedWith(annotationToProcess);
+        for (Element annotatedElement : annotatedElements) {
+            process((E) annotatedElement);
+        }
+    }
+
+    /** Processes a single annotated element. */
+    protected abstract void process(E annotatedElement) throws Exception;
+
+    /** Finds the annotation to process, or empty. */
+    private Optional<TypeElement> findAnnotationToProcess(Set<? extends TypeElement> annotations) {
+        return annotations.stream()
+                .filter(this::isAnnotationToProcess)
+                .map(TypeElement.class::cast)
+                .findFirst();
+    }
+
+    /** Determines if this annotation is the annotation to process. */
+    private boolean isAnnotationToProcess(TypeElement annotation) {
+        String annotationQualifiedName = annotation.getQualifiedName().toString();
+        return annotationQualifiedName.equals(targetAnnotationCanonicalName);
+    }
+}

--- a/processor/src/main/java/org/example/processor/base/LiteProcessor.java
+++ b/processor/src/main/java/org/example/processor/base/LiteProcessor.java
@@ -1,0 +1,25 @@
+package org.example.processor.base;
+
+import java.util.Set;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.element.TypeElement;
+
+/**
+ * Lightweight annotation processor.
+ *
+ * <p>{@link AdapterProcessor} can adapt a {@link LiteProcessor} to a {@link Processor}.</p>
+ */
+public interface LiteProcessor {
+
+    /**
+     * Corresponds to {@link Processor#process(Set, RoundEnvironment)} with a few simplifications:
+     *
+     * <ol>
+     *     <li>The set of annotations is never empty.</li>
+     *     <li>It does not return a value.</li>
+     *     <li>It can throw an {@link Exception}.</li>
+     * </ol>
+     */
+    void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws Exception;
+}

--- a/processor/src/main/java/org/example/processor/base/ProcessorModule.java
+++ b/processor/src/main/java/org/example/processor/base/ProcessorModule.java
@@ -1,0 +1,59 @@
+package org.example.processor.base;
+
+import dagger.Module;
+import dagger.Provides;
+import java.util.Locale;
+import java.util.Map;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Messager;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/** Provides objects that are part of the {@link ProcessingEnvironment}. */
+@Module
+public interface ProcessorModule {
+
+    @Provides
+    @ProcessorScope
+    static Elements provideElements(ProcessingEnvironment processingEnv) {
+        return processingEnv.getElementUtils();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Types provideTypes(ProcessingEnvironment processingEnv) {
+        return processingEnv.getTypeUtils();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Messager provideMessager(ProcessingEnvironment processingEnv) {
+        return processingEnv.getMessager();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Filer provideFiler(ProcessingEnvironment processingEnv) {
+        return processingEnv.getFiler();
+    }
+
+    @Provides
+    @ProcessorScope
+    static SourceVersion provideSourceVersion(ProcessingEnvironment processingEnvironment) {
+        return processingEnvironment.getSourceVersion();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Map<String, String> provideOptions(ProcessingEnvironment processingEnv) {
+        return processingEnv.getOptions();
+    }
+
+    @Provides
+    @ProcessorScope
+    static Locale provideLocale(ProcessingEnvironment processingEnv) {
+        return processingEnv.getLocale();
+    }
+}

--- a/processor/src/main/java/org/example/processor/base/ProcessorScope.java
+++ b/processor/src/main/java/org/example/processor/base/ProcessorScope.java
@@ -1,0 +1,14 @@
+package org.example.processor.base;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.inject.Scope;
+
+/** Scope for objects whose lifecycle begins with {@link Processor#init(ProcessingEnvironment)}. */
+@Scope
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface ProcessorScope {}

--- a/processor/src/test/java/org/example/processor/base/AdapterProcessorTest.java
+++ b/processor/src/test/java/org/example/processor/base/AdapterProcessorTest.java
@@ -1,0 +1,92 @@
+package org.example.processor.base;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.Iterables;
+import com.google.testing.compile.Compilation;
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Set;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Processor;
+import javax.annotation.processing.RoundEnvironment;
+import javax.inject.Inject;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
+import javax.tools.Diagnostic;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardLocation;
+import org.junit.jupiter.api.Test;
+
+public final class AdapterProcessorTest {
+
+    @Test
+    public void process() {
+        Processor processor = TestProcessor.of(TestLiteProcessor.class);
+        Compilation compilation = TestCompiler.compile(processor);
+        assertThat(compilation).succeededWithoutWarnings();
+        assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "equals"))
+                .isPresent();
+        assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "hashCode"))
+                .isPresent();
+        assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "toString"))
+                .isPresent();
+    }
+
+    @Test
+    public void handleUncaughtException() {
+        Processor processor = TestProcessor.of(ErrorLiteProcessor.class);
+        Compilation compilation = TestCompiler.compile(processor);
+        assertThat(compilation).failed();
+        assertThat(compilation.diagnostics()).hasSize(1);
+        Diagnostic<? extends JavaFileObject> diagnostic = Iterables.getOnlyElement(compilation.diagnostics());
+        assertThat(diagnostic.getKind()).isEqualTo(Diagnostic.Kind.ERROR);
+        String message = diagnostic.getMessage(Locale.US);
+        assertThat(message)
+                .startsWith("Uncaught exception processing annotations in org.example.processor.base.TestProcessor:");
+        assertThat(message).contains("java.lang.RuntimeException: error123");
+    }
+
+    /** Generates an empty file for each method annotated with {@link Override}. */
+    public static final class TestLiteProcessor implements LiteProcessor {
+
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(Filer filer) {
+            this.filer = filer;
+        }
+
+        @Override
+        public void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) throws IOException {
+            Set<? extends Element> annotatedElements = getAnnotatedElements(annotations, roundEnv);
+            for (Element annotatedElement : annotatedElements) {
+                generateTestResource(annotatedElement);
+            }
+        }
+
+        private Set<? extends Element> getAnnotatedElements(
+                Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            TypeElement annotation = Iterables.getOnlyElement(annotations);
+            return roundEnv.getElementsAnnotatedWith(annotation);
+        }
+
+        private void generateTestResource(Element annotatedElement) throws IOException {
+            String name = annotatedElement.getSimpleName().toString();
+            filer.createResource(StandardLocation.SOURCE_OUTPUT, "", name, annotatedElement);
+        }
+    }
+
+    /** Lite processor with an uncaught exception. */
+    public static final class ErrorLiteProcessor implements LiteProcessor {
+
+        @Inject
+        ErrorLiteProcessor() {}
+
+        @Override
+        public void process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
+            throw new RuntimeException("error123");
+        }
+    }
+}

--- a/processor/src/test/java/org/example/processor/base/IsolatingLiteProcessorTest.java
+++ b/processor/src/test/java/org/example/processor/base/IsolatingLiteProcessorTest.java
@@ -1,0 +1,47 @@
+package org.example.processor.base;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+
+import com.google.testing.compile.Compilation;
+import java.io.IOException;
+import javax.annotation.processing.Filer;
+import javax.annotation.processing.Processor;
+import javax.inject.Inject;
+import javax.lang.model.element.ExecutableElement;
+import javax.tools.StandardLocation;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public final class IsolatingLiteProcessorTest {
+
+    @Test
+    public void process() {
+        Processor processor = TestProcessor.of(TestLiteProcessor.class);
+        Compilation compilation = TestCompiler.compile(processor);
+        assertThat(compilation).succeededWithoutWarnings();
+        Assertions.assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "equals"))
+                .isPresent();
+        Assertions.assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "hashCode"))
+                .isPresent();
+        Assertions.assertThat(compilation.generatedFile(StandardLocation.SOURCE_OUTPUT, "toString"))
+                .isPresent();
+    }
+
+    /** Generates an empty file for each method annotated with {@link Override}. */
+    public static final class TestLiteProcessor extends IsolatingLiteProcessor<ExecutableElement> {
+
+        private final Filer filer;
+
+        @Inject
+        TestLiteProcessor(Filer filer) {
+            super(Override.class);
+            this.filer = filer;
+        }
+
+        @Override
+        protected void process(ExecutableElement annotatedElement) throws IOException {
+            String name = annotatedElement.getSimpleName().toString();
+            filer.createResource(StandardLocation.SOURCE_OUTPUT, "", name);
+        }
+    }
+}

--- a/processor/src/test/java/org/example/processor/base/TestCompiler.java
+++ b/processor/src/test/java/org/example/processor/base/TestCompiler.java
@@ -1,0 +1,22 @@
+package org.example.processor.base;
+
+import com.google.testing.compile.Compilation;
+import com.google.testing.compile.Compiler;
+import com.google.testing.compile.JavaFileObjects;
+import javax.annotation.processing.Processor;
+
+/** Compiles the test source with an annotation processor. */
+final class TestCompiler {
+
+    /** Compiles the test source with the provided processor. */
+    public static Compilation compile(Processor processor) {
+        return Compiler.javac()
+                .withProcessors(processor)
+                // Suppress this warning: "Implicitly compiled files were not subject to annotation processing."
+                .withOptions("-implicit:none")
+                .compile(JavaFileObjects.forResource("test/Test.java"));
+    }
+
+    // static class
+    private TestCompiler() {}
+}

--- a/processor/src/test/java/org/example/processor/base/TestProcessor.java
+++ b/processor/src/test/java/org/example/processor/base/TestProcessor.java
@@ -1,0 +1,73 @@
+package org.example.processor.base;
+
+import dagger.BindsInstance;
+import dagger.Component;
+import java.util.Set;
+import javax.annotation.processing.Completion;
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.annotation.processing.Processor;
+import javax.lang.model.SourceVersion;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+
+/** Processes methods annotated with {@link Override}, using the provided {@link LiteProcessor}. */
+final class TestProcessor extends AdapterProcessor {
+
+    private final Class<? extends LiteProcessor> liteProcessorClass;
+
+    public static Processor of(Class<? extends LiteProcessor> liteProcessorClass) {
+        return new TestProcessor(liteProcessorClass);
+    }
+
+    @Override
+    public Set<String> getSupportedOptions() {
+        return Set.of();
+    }
+
+    @Override
+    public Set<String> getSupportedAnnotationTypes() {
+        return Set.of(Override.class.getCanonicalName());
+    }
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
+
+    @Override
+    public Iterable<? extends Completion> getCompletions(
+            Element element, AnnotationMirror annotation, ExecutableElement member, String userText) {
+        return Set.of();
+    }
+
+    @Override
+    protected LiteProcessor createLiteProcessor(ProcessingEnvironment processingEnv) {
+        ProcessorComponent processorComponent = ProcessorComponent.of(processingEnv, liteProcessorClass);
+        return processorComponent.liteProcessor();
+    }
+
+    private TestProcessor(Class<? extends LiteProcessor> liteProcessorClass) {
+        this.liteProcessorClass = liteProcessorClass;
+    }
+
+    @Component(modules = {ProcessorModule.class, TestProcessorModule.class})
+    @ProcessorScope
+    interface ProcessorComponent {
+
+        static ProcessorComponent of(
+                ProcessingEnvironment processingEnv, Class<? extends LiteProcessor> liteProcessorClass) {
+            return DaggerTestProcessor_ProcessorComponent.factory().create(processingEnv, liteProcessorClass);
+        }
+
+        LiteProcessor liteProcessor();
+
+        @Component.Factory
+        interface Factory {
+
+            ProcessorComponent create(
+                    @BindsInstance ProcessingEnvironment processingEnv,
+                    @BindsInstance Class<? extends LiteProcessor> liteProcessorClass);
+        }
+    }
+}

--- a/processor/src/test/java/org/example/processor/base/TestProcessorModule.java
+++ b/processor/src/test/java/org/example/processor/base/TestProcessorModule.java
@@ -1,0 +1,62 @@
+package org.example.processor.base;
+
+import dagger.Binds;
+import dagger.Component;
+import dagger.MapKey;
+import dagger.Module;
+import dagger.Provides;
+import dagger.multibindings.IntoMap;
+import java.util.Map;
+import java.util.Objects;
+import javax.annotation.processing.Processor;
+
+/**
+ * Provides all test implementations of {@link LiteProcessor}
+ * as well as the selected implementation, using the {@link LiteProcessor} class as a key.
+ *
+ * <p>The design of this module is slightly convoluted,
+ * but it saves us from writing a separate {@link Component} and {@link Processor}
+ * for each test implementation of {@link LiteProcessor}.</p>
+ */
+@Module
+interface TestProcessorModule {
+
+    /** Selects a {@link LiteProcessor} from all available test implementations.  */
+    @Provides
+    @ProcessorScope
+    static LiteProcessor provideLiteProcessor(
+            Map<Class<? extends LiteProcessor>, LiteProcessor> liteProcessors, Class<? extends LiteProcessor> key) {
+        LiteProcessor liteProcessor = liteProcessors.get(key);
+        Objects.requireNonNull(liteProcessor);
+        return Objects.requireNonNull(liteProcessor);
+    }
+
+    @MapKey
+    @interface LiteProcessorClassKey {
+
+        Class<? extends LiteProcessor> value();
+    }
+
+    /*
+     * Add test implementations of LiteProcessor below (in import order).
+     */
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(AdapterProcessorTest.ErrorLiteProcessor.class)
+    LiteProcessor bindAdapterProcessorTest_ErrorLiteProcessor(AdapterProcessorTest.ErrorLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(AdapterProcessorTest.TestLiteProcessor.class)
+    LiteProcessor bindAdapterProcessorTest_TestLiteProcessor(AdapterProcessorTest.TestLiteProcessor liteProcessor);
+
+    @Binds
+    @ProcessorScope
+    @IntoMap
+    @LiteProcessorClassKey(IsolatingLiteProcessorTest.TestLiteProcessor.class)
+    LiteProcessor bindIsolatingLiteProcessorTest_TestLiteProcessor(
+            IsolatingLiteProcessorTest.TestLiteProcessor liteProcessor);
+}

--- a/processor/src/test/resources/test/Test.java
+++ b/processor/src/test/resources/test/Test.java
@@ -1,0 +1,19 @@
+package test;
+
+public final class Test {
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof Test;
+    }
+
+    @Override
+    public int hashCode() {
+        return 0;
+    }
+
+    @Override
+    public String toString() {
+        return "Test";
+    }
+}


### PR DESCRIPTION
`org.example.processor.base` package:

- simplified `LiteProcessor` interface
- `IsolatingLiteProcessor` abstract class, where each output is generated from a single input
- `AdapterProcesssor` to adapt a `LiteProcessor` to a `Processor`
  - `AdapterProcessor` also handles uncaught exceptions from the `LiteProcessor`.
- `ProcessorModule`, `ProcessorScope` for dependency injection with Dagger

Tests demonstrate how to use all of this in practice.